### PR TITLE
Refactor test code to support PHPUnit's new event system

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,11 +4,10 @@
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="vendor/autoload.php"
     colors="true">
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
+
+    <extensions>
+        <bootstrap class="LaminasIntegrationTest\Db\Extension\ListenerExtension" />
+    </extensions>
 
     <testsuites>
         <testsuite name="unit test">
@@ -19,9 +18,6 @@
         </testsuite>
     </testsuites>
 
-    <listeners>
-        <listener class="LaminasIntegrationTest\Db\IntegrationTestListener" file="./test/integration/IntegrationTestListener.php"/>
-    </listeners>
 
     <php>
         <!-- Note: the following is a FULL list of ALL POSSIBLE constants

--- a/test/integration/Extension/IntegrationTestStartedListener.php
+++ b/test/integration/Extension/IntegrationTestStartedListener.php
@@ -1,29 +1,25 @@
 <?php
 
-namespace LaminasIntegrationTest\Db;
+namespace LaminasIntegrationTest\Db\Extension;
 
 use LaminasIntegrationTest\Db\Platform\FixtureLoader;
 use LaminasIntegrationTest\Db\Platform\MysqlFixtureLoader;
 use LaminasIntegrationTest\Db\Platform\PgsqlFixtureLoader;
 use LaminasIntegrationTest\Db\Platform\SqlServerFixtureLoader;
-use PHPUnit\Framework\TestListener;
-use PHPUnit\Framework\TestListenerDefaultImplementation;
-use PHPUnit\Framework\TestSuite;
-use PHPUnit\Runner\TestHook;
+use PHPUnit\Event\TestSuite\Started;
+use PHPUnit\Event\TestSuite\StartedSubscriber;
 
 use function getenv;
 use function printf;
 
-class IntegrationTestListener implements TestHook, TestListener
+final class IntegrationTestStartedListener implements StartedSubscriber
 {
-    use TestListenerDefaultImplementation;
-
     /** @var FixtureLoader[] */
     private $fixtureLoaders = [];
 
-    public function startTestSuite(TestSuite $suite): void
+    public function notify(Started $event): void
     {
-        if ($suite->getName() !== 'integration test') {
+        if ($event->testSuite()->name() !== 'integration test') {
             return;
         }
 
@@ -47,22 +43,6 @@ class IntegrationTestListener implements TestHook, TestListener
 
         foreach ($this->fixtureLoaders as $fixtureLoader) {
             $fixtureLoader->createDatabase();
-        }
-    }
-
-    public function endTestSuite(TestSuite $suite): void
-    {
-        if (
-            $suite->getName() !== 'integration test'
-            || empty($this->fixtureLoaders)
-        ) {
-            return;
-        }
-
-        printf("\nIntegration test ended.\n");
-
-        foreach ($this->fixtureLoaders as $fixtureLoader) {
-            $fixtureLoader->dropDatabase();
         }
     }
 }

--- a/test/integration/Extension/IntegrationTestStoppedListener.php
+++ b/test/integration/Extension/IntegrationTestStoppedListener.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LaminasIntegrationTest\Db\Extension;
+
+use LaminasIntegrationTest\Db\Platform\FixtureLoader;
+use PHPUnit\Event\TestSuite\Finished;
+use PHPUnit\Event\TestSuite\FinishedSubscriber;
+
+use function printf;
+
+final class IntegrationTestStoppedListener implements FinishedSubscriber
+{
+    /** @var FixtureLoader[] */
+    private $fixtureLoaders = [];
+
+    public function notify(Finished $event): void
+    {
+        if (
+            $event->testSuite()->name() !== 'integration test'
+            || empty($this->fixtureLoaders)
+        ) {
+            return;
+        }
+
+        printf("\nIntegration test ended.\n");
+
+        foreach ($this->fixtureLoaders as $fixtureLoader) {
+            $fixtureLoader->dropDatabase();
+        }
+    }
+}

--- a/test/integration/Extension/ListenerExtension.php
+++ b/test/integration/Extension/ListenerExtension.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LaminasIntegrationTest\Db\Extension;
+
+use PHPUnit\Runner\Extension\Extension;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\TextUI\Configuration\Configuration;
+
+final class ListenerExtension implements Extension
+{
+    public function bootstrap(
+        Configuration $configuration,
+        Facade $facade,
+        ParameterCollection $parameters
+    ): void {
+        $facade->registerSubscribers(
+            new IntegrationTestStartedListener(),
+            new IntegrationTestStoppedListener(),
+        );
+    }
+}


### PR DESCRIPTION
This PR refactors some of the test code to support PHPUnit's most recent iteration of its event system. The previous iteration worked for earlier versions, but there was a newer version release in PHPUnit 10.0.7. For further details about the latest iteration of the event system, check out [the excellent write up](https://localheinz.com/articles/2023/02/14/extending-phpunit-with-its-new-event-system/#content-events-in-the-new-event-system) from @localheinz.