### PR TITLE
Update MySQL Docker base image

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -16,7 +16,7 @@ services:
       context: ./
       dockerfile: docker/databases/mysql/Dockerfile
       args:
-        - VERSION=${MYSQL_VERSION:-8.0.41}
+        - VERSION=${MYSQL_VERSION:-oraclelinux9}
     ports:
       - "3306:3306"
     environment:

--- a/docker/databases/mysql/Dockerfile
+++ b/docker/databases/mysql/Dockerfile
@@ -1,3 +1,3 @@
-ARG VERSION=8.4.5
+ARG VERSION=oraclelinux9
 
-FROM mysql:${VERSION}-bookworm AS base
+FROM mysql:${VERSION} AS base


### PR DESCRIPTION
This change ensures that the MySQL service will run on macOS as well as Linux and Windows by using a MySQL image that supports all three OS architectures. The previous image only supported Linux and Windows.