### PR TITLE
Fix return type for SchemaAwareInterface::getCurrentSchema(): string|false

### DIFF
--- a/src/Adapter/Adapter.php
+++ b/src/Adapter/Adapter.php
@@ -65,7 +65,7 @@ class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface, Sche
     }
 
     #[Override]
-    public function getCurrentSchema(): string
+    public function getCurrentSchema(): string|false
     {
         return $this->driver->getConnection()->getCurrentSchema();
     }

--- a/src/Adapter/SchemaAwareInterface.php
+++ b/src/Adapter/SchemaAwareInterface.php
@@ -6,10 +6,10 @@ namespace PhpDb\Adapter;
 
 interface SchemaAwareInterface
 {
-        /**
+    /**
      * Get current schema
      *
      * todo: narrow this to string|false when version bumps to PHP 8.2 minimum
      */
-    public function getCurrentSchema(): string|bool;
+    public function getCurrentSchema(): string|false;
 }


### PR DESCRIPTION
Signed-off-by: Joey Smith <jsmith@webinertia.net>

Signed-off-by: Joey Smith <jsmith@webinertia.net>


Description:
