### PR TITLE
Align resultset prototype implementations

### DIFF
--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpDb\ResultSet;
 
 use ArrayIterator;

--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -7,6 +7,7 @@ use Countable;
 use Exception;
 use Iterator;
 use IteratorAggregate;
+use Override;
 use PhpDb\Adapter\Driver\ResultInterface;
 use PhpDb\ResultSet\Exception\InvalidArgumentException;
 use PhpDb\ResultSet\Exception\RuntimeException;
@@ -44,8 +45,8 @@ abstract class AbstractResultSet implements ResultSetInterface
      * Set the data source for the result set
      *
      * @throws InvalidArgumentException|Exception
-     * @return $this Provides a fluent interface
      */
+    #[Override]
     public function initialize(iterable $dataSource): ResultSetInterface
     {
         // reset buffering
@@ -121,6 +122,7 @@ abstract class AbstractResultSet implements ResultSetInterface
     /**
      * Retrieve count of fields in individual rows of the result set
      */
+    #[Override]
     public function getFieldCount(): mixed
     {
         if (null !== $this->fieldCount) {
@@ -152,6 +154,7 @@ abstract class AbstractResultSet implements ResultSetInterface
     /**
      * Iterator: move pointer to next item
      */
+    #[Override]
     public function next(): void
     {
         if ($this->buffer === null) {
@@ -167,6 +170,7 @@ abstract class AbstractResultSet implements ResultSetInterface
     /**
      * Iterator: retrieve current key
      */
+    #[Override]
     public function key(): int
     {
         return $this->position;
@@ -175,6 +179,7 @@ abstract class AbstractResultSet implements ResultSetInterface
     /**
      * Iterator: get current item
      */
+    #[Override]
     public function current(): array|object|null
     {
         if (-1 === $this->buffer) {
@@ -197,6 +202,7 @@ abstract class AbstractResultSet implements ResultSetInterface
     /**
      * Iterator: is pointer valid?
      */
+    #[Override]
     public function valid(): bool
     {
         if (is_array($this->buffer) && isset($this->buffer[$this->position])) {
@@ -213,6 +219,7 @@ abstract class AbstractResultSet implements ResultSetInterface
     /**
      * Iterator: rewind
      */
+    #[Override]
     public function rewind(): void
     {
         if (! is_array($this->buffer)) {
@@ -228,6 +235,7 @@ abstract class AbstractResultSet implements ResultSetInterface
     /**
      * Countable: return count of rows
      */
+    #[Override]
     #[ReturnTypeWillChange]
     public function count(): ?int
     {

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -15,7 +15,7 @@ class HydratingResultSet extends AbstractResultSet
 {
     public function __construct(
         private HydratorInterface $hydrator = new ArraySerializableHydrator(),
-        private object $rowPrototype     = new ArrayObject()
+        private ?object $rowPrototype       = new ArrayObject()
     ) {
     }
 
@@ -77,7 +77,7 @@ class HydratingResultSet extends AbstractResultSet
             return $this->buffer[$this->position];
         }
         $data    = $this->dataSource->current();
-        $current = is_array($data) ? $this->hydrator->hydrate($data, clone $this->objectPrototype) : null;
+        $current = is_array($data) ? $this->hydrator->hydrate($data, clone $this->rowPrototype) : null;
 
         if (is_array($this->buffer)) {
             $this->buffer[$this->position] = $current;

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -1,54 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpDb\ResultSet;
 
 use ArrayObject;
 use Laminas\Hydrator\ArraySerializableHydrator;
 use Laminas\Hydrator\HydratorInterface;
+use Override;
 
-use function gettype;
 use function is_array;
-use function is_object;
 
 class HydratingResultSet extends AbstractResultSet
 {
-    protected HydratorInterface $hydrator;
-
-    protected ?object $objectPrototype;
-
-    /**
-     * Constructor
-     */
-    public function __construct(?HydratorInterface $hydrator = null, ?object $objectPrototype = null)
-    {
-        $defaultHydratorClass = ArraySerializableHydrator::class;
-        $this->setHydrator($hydrator ?: new $defaultHydratorClass());
-        $this->setObjectPrototype($objectPrototype ?: new ArrayObject());
-    }
-
-    /**
-     * Set the row object prototype
-     *
-     * @throws Exception\InvalidArgumentException
-     * @return $this Provides a fluent interface
-     */
-    public function setObjectPrototype(object $objectPrototype): static
-    {
-        if (! is_object($objectPrototype)) {
-            throw new Exception\InvalidArgumentException(
-                'An object must be set as the object prototype, a ' . gettype($objectPrototype) . ' was provided.'
-            );
-        }
-        $this->objectPrototype = $objectPrototype;
-        return $this;
-    }
-
-    /**
-     * Get the row object prototype
-     */
-    public function getObjectPrototype(): ?object
-    {
-        return $this->objectPrototype;
+    public function __construct(
+        private HydratorInterface $hydrator = new ArraySerializableHydrator(),
+        private object $objectPrototype     = new ArrayObject()
+    ) {
     }
 
     /**
@@ -56,7 +24,7 @@ class HydratingResultSet extends AbstractResultSet
      *
      * @return $this Provides a fluent interface
      */
-    public function setHydrator(HydratorInterface $hydrator): static
+    public function setHydrator(HydratorInterface $hydrator): ResultSetInterface
     {
         $this->hydrator = $hydrator;
         return $this;
@@ -69,10 +37,25 @@ class HydratingResultSet extends AbstractResultSet
     {
         return $this->hydrator;
     }
+    /** {@inheritDoc} */
+    #[Override]
+    public function setObjectPrototype(object $objectPrototype): ResultSetInterface
+    {
+        $this->objectPrototype = $objectPrototype;
+        return $this;
+    }
+
+    /** {@inheritDoc} */
+    #[Override]
+    public function getObjectPrototype(): ?object
+    {
+        return $this->objectPrototype;
+    }
 
     /**
      * Iterator: get current item
      */
+    #[Override]
     public function current(): ?object
     {
         if ($this->buffer === null) {
@@ -95,6 +78,7 @@ class HydratingResultSet extends AbstractResultSet
      *
      * @throws Exception\RuntimeException If any row is not castable to an array.
      */
+    #[Override]
     public function toArray(): array
     {
         $return = [];

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -15,7 +15,7 @@ class HydratingResultSet extends AbstractResultSet
 {
     public function __construct(
         private HydratorInterface $hydrator = new ArraySerializableHydrator(),
-        private object $objectPrototype     = new ArrayObject()
+        private object $rowPrototype     = new ArrayObject()
     ) {
     }
 
@@ -37,19 +37,33 @@ class HydratingResultSet extends AbstractResultSet
     {
         return $this->hydrator;
     }
+
     /** {@inheritDoc} */
     #[Override]
+    public function setRowPrototype(ArrayObject $rowPrototype): ResultSetInterface
+    {
+        $this->rowPrototype = $rowPrototype;
+        return $this;
+    }
+
+    /** {@inheritDoc} */
+    #[Override]
+    public function getRowPrototype(): ?object
+    {
+        return $this->rowPrototype;
+    }
+
+    /** @deprecated use setRowPrototype() */
     public function setObjectPrototype(object $objectPrototype): ResultSetInterface
     {
-        $this->objectPrototype = $objectPrototype;
-        return $this;
+        return  $this->setRowPrototype($objectPrototype);
     }
 
     /** {@inheritDoc} */
     #[Override]
     public function getObjectPrototype(): ?object
     {
-        return $this->objectPrototype;
+        return $this->getRowPrototype();
     }
 
     /**

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -59,8 +59,7 @@ class HydratingResultSet extends AbstractResultSet
         return  $this->setRowPrototype($objectPrototype);
     }
 
-    /** {@inheritDoc} */
-    #[Override]
+    /** @deprecated use getRowPrototype() */
     public function getObjectPrototype(): ?object
     {
         return $this->getRowPrototype();

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -58,6 +58,16 @@ class ResultSet extends AbstractResultSet
         return $this;
     }
 
+    public function setObjectPrototype(ArrayObject $objectPrototype): static
+    {
+        if (! $objectPrototype instanceof ArrayObject) {
+            throw new Exception\InvalidArgumentException(
+                'Object prototype must be an instance of ArrayObject'
+            );
+        }
+        return $this->setArrayObjectPrototype($objectPrototype);
+    }
+
     /**
      * Get the row object prototype
      */

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -1,79 +1,41 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpDb\ResultSet;
 
 use ArrayObject;
 
-use function in_array;
 use function is_array;
-use function method_exists;
 
 class ResultSet extends AbstractResultSet
 {
+    /** @deprecated use ResultSetReturnType */
     public const TYPE_ARRAYOBJECT = 'arrayobject';
     public const TYPE_ARRAY       = 'array';
 
-    /**
-     * Allowed return types
-     */
-    protected array $allowedReturnTypes = [
-        self::TYPE_ARRAYOBJECT,
-        self::TYPE_ARRAY,
-    ];
-
-    protected ArrayObject $arrayObjectPrototype;
-
-    /**
-     * Return type to use when returning an object from the set
-     */
-    protected string $returnType = self::TYPE_ARRAYOBJECT;
-
-    /**
-     * Constructor
-     */
-    public function __construct(string $returnType = self::TYPE_ARRAYOBJECT, ?ArrayObject $arrayObjectPrototype = null)
-    {
-        $this->returnType = in_array($returnType, $this->allowedReturnTypes, true) ?
-            $returnType : self::TYPE_ARRAYOBJECT;
-
-        if ($this->returnType === self::TYPE_ARRAYOBJECT) {
-            $this->setArrayObjectPrototype($arrayObjectPrototype ?: new ArrayObject([], ArrayObject::ARRAY_AS_PROPS));
+    public function __construct(
+        private ResultSetReturnType|string $returnType = ResultSetReturnType::ArrayObject,
+        private ArrayObject $objectPrototype = new ArrayObject([], ArrayObject::ARRAY_AS_PROPS)
+    ) {
+        if (is_string($this->returnType)) {
+            $this->returnType = ResultSetReturnType::from($this->returnType);
         }
     }
 
-    /**
-     * Set the row object prototype
-     *
-     * @throws Exception\InvalidArgumentException
-     * @return $this Provides a fluent interface
-     */
-    public function setArrayObjectPrototype(ArrayObject $arrayObjectPrototype): static
+    /** {@inheritDoc} */
+    #[Override]
+    public function setObjectPrototype(ArrayObject $objectPrototype): ResultSetInterface
     {
-        if (! method_exists($arrayObjectPrototype, 'exchangeArray')) {
-            throw new Exception\InvalidArgumentException(
-                'Object must at least implement exchangeArray'
-            );
-        }
-        $this->arrayObjectPrototype = $arrayObjectPrototype;
+        $this->objectPrototype = $objectPrototype;
         return $this;
     }
 
-    public function setObjectPrototype(ArrayObject $objectPrototype): static
+    /** {@inheritDoc} */
+    #[Override]
+    public function getObjectPrototype(): ArrayObject
     {
-        if (! $objectPrototype instanceof ArrayObject) {
-            throw new Exception\InvalidArgumentException(
-                'Object prototype must be an instance of ArrayObject'
-            );
-        }
-        return $this->setArrayObjectPrototype($objectPrototype);
-    }
-
-    /**
-     * Get the row object prototype
-     */
-    public function getArrayObjectPrototype(): ArrayObject
-    {
-        return $this->arrayObjectPrototype;
+        return $this->objectPrototype;
     }
 
     /**
@@ -84,18 +46,38 @@ class ResultSet extends AbstractResultSet
         return $this->returnType;
     }
 
-    public function current(): array|object|null
+    /**
+     * Iterator: get current item
+     */
+    #[Override]
+    public function current(): array|ArrayObject|null
     {
         $data = parent::current();
 
-        if ($this->returnType === self::TYPE_ARRAYOBJECT && is_array($data)) {
-            $ao = clone $this->arrayObjectPrototype;
-            if ($ao instanceof ArrayObject || method_exists($ao, 'exchangeArray')) {
-                $ao->exchangeArray($data);
-            }
+        if ($this->returnType === ResultSetReturnType::ArrayObject && is_array($data)) {
+            $ao = clone $this->objectPrototype;
+            $ao->exchangeArray($data);
             return $ao;
         }
 
         return $data;
+    }
+
+    /**
+     * Set the row object prototype
+     *
+     * @deprecated use setObjectPrototype()
+     */
+    public function setArrayObjectPrototype(ArrayObject $arrayObjectPrototype): ResultSetInterface
+    {
+        return $this->setObjectPrototype($arrayObjectPrototype);
+    }
+
+    /**
+     * @deprecated use getObjectPrototype()
+     */
+    public function getArrayObjectPrototype(): ArrayObject
+    {
+        return $this->getObjectPrototype();
     }
 }

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -17,7 +17,7 @@ class ResultSet extends AbstractResultSet
 
     public function __construct(
         private ResultSetReturnType|string $returnType = ResultSetReturnType::ArrayObject,
-        private ?ArrayObject $objectPrototype = new ArrayObject([], ArrayObject::ARRAY_AS_PROPS)
+        private ?ArrayObject $rowPrototype = new ArrayObject([], ArrayObject::ARRAY_AS_PROPS)
     ) {
         if (is_string($this->returnType)) {
             $this->returnType = ResultSetReturnType::from($this->returnType);
@@ -28,7 +28,7 @@ class ResultSet extends AbstractResultSet
     #[Override]
     public function setRowPrototype(ArrayObject $rowPrototype): ResultSetInterface
     {
-        $this->objectPrototype = $rowPrototype;
+        $this->rowPrototype = $rowPrototype;
         return $this;
     }
 
@@ -36,7 +36,7 @@ class ResultSet extends AbstractResultSet
     #[Override]
     public function getRowPrototype(): ArrayObject
     {
-        return $this->objectPrototype;
+        return $this->rowPrototype;
     }
 
     /**
@@ -56,7 +56,7 @@ class ResultSet extends AbstractResultSet
         $data = parent::current();
 
         if ($this->returnType === ResultSetReturnType::ArrayObject && is_array($data)) {
-            $ao = clone $this->objectPrototype;
+            $ao = clone $this->rowPrototype;
             $ao->exchangeArray($data);
             return $ao;
         }

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpDb\ResultSet;
 
 use ArrayObject;
+use Override;
 
 use function is_array;
 
@@ -16,7 +17,7 @@ class ResultSet extends AbstractResultSet
 
     public function __construct(
         private ResultSetReturnType|string $returnType = ResultSetReturnType::ArrayObject,
-        private ArrayObject $objectPrototype = new ArrayObject([], ArrayObject::ARRAY_AS_PROPS)
+        private ?ArrayObject $objectPrototype = new ArrayObject([], ArrayObject::ARRAY_AS_PROPS)
     ) {
         if (is_string($this->returnType)) {
             $this->returnType = ResultSetReturnType::from($this->returnType);
@@ -25,15 +26,15 @@ class ResultSet extends AbstractResultSet
 
     /** {@inheritDoc} */
     #[Override]
-    public function setObjectPrototype(ArrayObject $objectPrototype): ResultSetInterface
+    public function setRowPrototype(ArrayObject $rowPrototype): ResultSetInterface
     {
-        $this->objectPrototype = $objectPrototype;
+        $this->objectPrototype = $rowPrototype;
         return $this;
     }
 
     /** {@inheritDoc} */
     #[Override]
-    public function getObjectPrototype(): ArrayObject
+    public function getRowPrototype(): ArrayObject
     {
         return $this->objectPrototype;
     }
@@ -70,7 +71,7 @@ class ResultSet extends AbstractResultSet
      */
     public function setArrayObjectPrototype(ArrayObject $arrayObjectPrototype): ResultSetInterface
     {
-        return $this->setObjectPrototype($arrayObjectPrototype);
+        return $this->setRowPrototype($arrayObjectPrototype);
     }
 
     /**
@@ -78,6 +79,6 @@ class ResultSet extends AbstractResultSet
      */
     public function getArrayObjectPrototype(): ArrayObject
     {
-        return $this->getObjectPrototype();
+        return $this->getRowPrototype();
     }
 }

--- a/src/ResultSet/ResultSetInterface.php
+++ b/src/ResultSet/ResultSetInterface.php
@@ -20,5 +20,5 @@ interface ResultSetInterface extends Iterator, Countable
      */
     public function getFieldCount(): mixed;
 
-    public function setObjectPrototype(ArrayObject $ObjectPrototype): ResultSetInterface;
+    public function setObjectPrototype(object $ObjectPrototype): ResultSetInterface;
 }

--- a/src/ResultSet/ResultSetInterface.php
+++ b/src/ResultSet/ResultSetInterface.php
@@ -2,6 +2,7 @@
 
 namespace PhpDb\ResultSet;
 
+use ArrayObject;
 use Countable;
 use Iterator;
 
@@ -18,4 +19,6 @@ interface ResultSetInterface extends Iterator, Countable
      * operation or intersection of some data
      */
     public function getFieldCount(): mixed;
+
+    public function setObjectPrototype(ArrayObject $ObjectPrototype): ResultSetInterface;
 }

--- a/src/ResultSet/ResultSetInterface.php
+++ b/src/ResultSet/ResultSetInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpDb\ResultSet;
 
 use ArrayObject;
@@ -20,5 +22,16 @@ interface ResultSetInterface extends Iterator, Countable
      */
     public function getFieldCount(): mixed;
 
-    public function setObjectPrototype(object $ObjectPrototype): ResultSetInterface;
+    /**
+     * Set the row object prototype
+     *
+     * @throws Exception\InvalidArgumentException
+     * @return $this Provides a fluent interface
+     */
+    public function setObjectPrototype(ArrayObject $ObjectPrototype): ResultSetInterface;
+
+    /**
+     * Get the row object prototype
+     */
+    public function getObjectPrototype(): ?object;
 }

--- a/src/ResultSet/ResultSetInterface.php
+++ b/src/ResultSet/ResultSetInterface.php
@@ -28,10 +28,10 @@ interface ResultSetInterface extends Iterator, Countable
      * @throws Exception\InvalidArgumentException
      * @return $this Provides a fluent interface
      */
-    public function setObjectPrototype(ArrayObject $ObjectPrototype): ResultSetInterface;
+    public function setRowPrototype(ArrayObject $rowPrototype): ResultSetInterface;
 
     /**
      * Get the row object prototype
      */
-    public function getObjectPrototype(): ?object;
+    public function getRowPrototype(): ?object;
 }

--- a/src/ResultSet/ResultSetReturnType.php
+++ b/src/ResultSet/ResultSetReturnType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDb\ResultSet;
+
+enum ResultSetReturnType:string
+{
+    case ArrayObject = 'arrayobject';
+    case Array       = 'array';
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes
| House Keeping | yes

### Description
Simplifies and slightly improves the ResultSetInterface implementations. Tightens up typing to the extent possible (I hope) and unifies ResultSet and HydratingResultSet by deprecating the old setArrayObjectPrototype/setObjectPrototype methods and replacing their usage with setRowPrototype. 

Old methods have been left in place and now proxy to the current methods.

Both implementations' constructors have been simplified.
