### PR TITLE
Remove readonly constraint from AbstractPdo driver to allow concrete …

### DIFF
--- a/src/Adapter/Driver/Pdo/AbstractPdo.php
+++ b/src/Adapter/Driver/Pdo/AbstractPdo.php
@@ -31,9 +31,9 @@ abstract class AbstractPdo implements PdoDriverInterface, ProfilerAwareInterface
     protected ?ProfilerInterface $profiler;
 
     public function __construct(
-        protected readonly AbstractPdoConnection|PDO $connection,
-        protected readonly StatementInterface&PdoDriverAwareInterface $statementPrototype,
-        protected readonly ResultInterface $resultPrototype,
+        protected AbstractPdoConnection|PDO $connection,
+        protected StatementInterface&PdoDriverAwareInterface $statementPrototype,
+        protected ResultInterface $resultPrototype,
         array $features = [],
     ) {
         if ($this->connection instanceof PdoDriverAwareInterface) {


### PR DESCRIPTION
…classes to provide defaults.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | sorta
| BC Break      | no
| New Feature   | sorta
| RFC           | no
| QA            | no
| House Keeping | no

### Description
In response to a conversation with @simon-mundy I am refactoring the creation context of certain services to allow providing default instances, where possible.
