### PR TITLE
Remove readonly from adapter

### DIFF
--- a/src/Adapter/Adapter.php
+++ b/src/Adapter/Adapter.php
@@ -20,9 +20,9 @@ class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface, Sche
      * @throws Exception\InvalidArgumentException
      */
     public function __construct(
-        protected readonly Driver\DriverInterface $driver,
-        protected readonly Platform\PlatformInterface $platform,
-        protected readonly ResultSet\ResultSetInterface $queryResultSetPrototype,
+        protected Driver\DriverInterface $driver,
+        protected Platform\PlatformInterface $platform,
+        protected ResultSet\ResultSetInterface $queryResultSetPrototype = new ResultSet\ResultSet(),
         protected ?Profiler\ProfilerInterface $profiler = null
     ) {
         if ($profiler) {

--- a/src/Container/AdapterAbstractServiceFactory.php
+++ b/src/Container/AdapterAbstractServiceFactory.php
@@ -16,6 +16,8 @@ use function is_array;
  * Database adapter abstract service factory.
  *
  * Allows configuring several database instances (such as writer and reader).
+ *
+ * @internal
  */
 class AdapterAbstractServiceFactory implements AbstractFactoryInterface
 {


### PR DESCRIPTION
Signed-off-by: Joey Smith <jsmith@webinertia.net>

Signed-off-by: Joey Smith <jsmith@webinertia.net>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no
| House Keeping | yes/no

### Description

Removes readonly from adapter construct method so default instances can be provided.