### PR TITLE
Delegates adapter creation back to php-db/phpdb

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -38,6 +38,9 @@ final class ConfigProvider
             'aliases'            => [
                 Adapter\AdapterInterface::class => Adapter\Adapter::class,
             ],
+            'factories'          => [
+                Adapter\Adapter::class => Container\AdapterInterfaceFactory::class,
+            ],
         ];
     }
 }

--- a/src/Container/AbstractAdapterInterfaceFactory.php
+++ b/src/Container/AbstractAdapterInterfaceFactory.php
@@ -14,6 +14,7 @@ use PhpDb\Adapter\Platform\PlatformInterface;
 use PhpDb\Adapter\Profiler\ProfilerInterface;
 use PhpDb\ConfigProvider;
 use PhpDb\Exception\ContainerException;
+use PhpDb\ResultSet\ResultSet;
 use PhpDb\ResultSet\ResultSetInterface;
 use Psr\Container\ContainerInterface;
 
@@ -26,7 +27,7 @@ use function is_array;
  *
  * @internal
  */
-class AbstractAdapterInterfaceFactory implements AbstractFactoryInterface
+final class AbstractAdapterInterfaceFactory implements AbstractFactoryInterface
 {
     protected ?array $config = null;
 
@@ -49,7 +50,7 @@ class AbstractAdapterInterfaceFactory implements AbstractFactoryInterface
     }
 
     /**
-     * Create a DB adapter
+     * Create a "Named" DB adapter
      *
      * @phpstan-param ContainerInterface&ServiceManager $container
      * @param string $requestedName
@@ -59,7 +60,7 @@ class AbstractAdapterInterfaceFactory implements AbstractFactoryInterface
         $requestedName,
         ?array $options = null
     ): AdapterInterface&Adapter {
-        /** @var string|null $driverClass */
+        /** @var class-string<DriverInterface>|class-string<PdoDriverInterface>|null $driverClass */
         $driverClass = $this->config[$requestedName]['driver'] ?? null;
 
         if ($driverClass === null) {
@@ -72,44 +73,30 @@ class AbstractAdapterInterfaceFactory implements AbstractFactoryInterface
 
         /** @var DriverInterface|PdoDriverInterface $driver */
         $driver = $container->build($driverClass, $this->config[$requestedName]);
+
         /** @var PlatformInterface $platform */
         $platform = $container->build(PlatformInterface::class, ['driver' => $driver]);
+
         /** @var ResultSetInterface|null $resultSet */
         $resultSet = $container->has(ResultSetInterface::class)
             ? $container->build(ResultSetInterface::class)
-            : null;
+            : new ResultSet();
+
         /** @var ProfilerInterface|null $profiler */
         $profiler = $container->has(ProfilerInterface::class)
             ? $container->build(ProfilerInterface::class)
             : null;
 
-        return match (true) {
-            $resultSet !== null && $profiler !== null => new Adapter(
-                driver: $driver,
-                platform: $platform,
-                queryResultSetPrototype: $resultSet,
-                profiler: $profiler,
-            ),
-            $resultSet !== null => new Adapter(
-                driver: $driver,
-                platform: $platform,
-                queryResultSetPrototype: $resultSet,
-            ),
-            $profiler !== null => new Adapter(
-                driver: $driver,
-                platform: $platform,
-                profiler: $profiler,
-            ),
-            default => new Adapter(
-                driver: $driver,
-                platform: $platform,
-            ),
-        };
+        return new Adapter(
+            driver: $driver,
+            platform: $platform,
+            queryResultSetPrototype: $resultSet,
+            profiler: $profiler,
+        );
     }
 
     /**
      * Get db configuration, if any
-     * todo: refactor to use PhpDb\ConfigProvider::NAMED_ADAPTER_KEY instead of hardcoding 'adapters'
      */
     protected function getConfig(ContainerInterface $container): array
     {

--- a/src/Container/AdapterInterfaceDelegator.php
+++ b/src/Container/AdapterInterfaceDelegator.php
@@ -14,7 +14,7 @@ use Psr\Container\NotFoundExceptionInterface;
 
 use function sprintf;
 
-class AdapterServiceDelegator
+class AdapterInterfaceDelegator
 {
     public function __construct(
         protected readonly string $adapterName = AdapterInterface::class

--- a/src/Container/AdapterInterfaceFactory.php
+++ b/src/Container/AdapterInterfaceFactory.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDb\Container;
+
+use Laminas\ServiceManager\ServiceManager;
+use PhpDb\Adapter\Adapter;
+use PhpDb\Adapter\AdapterInterface;
+use PhpDb\Adapter\Driver\DriverInterface;
+use PhpDb\Adapter\Driver\PdoDriverInterface;
+use PhpDb\Adapter\Platform\PlatformInterface;
+use PhpDb\Adapter\Profiler\ProfilerInterface;
+use PhpDb\Exception\ContainerException;
+use PhpDb\ResultSet\ResultSet;
+use PhpDb\ResultSet\ResultSetInterface;
+use Psr\Container\ContainerInterface;
+
+final class AdapterInterfaceFactory
+{
+    public function __invoke(
+        ContainerInterface&ServiceManager $container,
+        string $requestedName,
+    ): AdapterInterface&Adapter {
+        if (! $container->has('config')) {
+            throw ContainerException::forService(
+                $requestedName,
+                self::class,
+                'Container is missing a config service'
+            );
+        }
+        $config        = $container->get('config') ?? [];
+        $adapterConfig = $config[AdapterInterface::class] ?? $config[Adapter::class] ?? [];
+
+        if ($adapterConfig === []) {
+            throw ContainerException::forService(
+                AdapterInterface::class,
+                self::class,
+                'No configuration found for ' . $requestedName
+            );
+        }
+
+        /** @var class-string<DriverInterface>|class-string<PdoDriverInterface>|null $driverClass */
+        $driverClass = $adapterConfig['driver'] ?? null;
+
+        if ($driverClass === null || ! $container->has($driverClass)) {
+            throw ContainerException::forService(
+                AdapterInterface::class,
+                self::class,
+                'Invalid or missing driver provided for ' . $requestedName
+            );
+        }
+
+        /** @var DriverInterface|PdoDriverInterface $driver */
+        $driver = $container->build($driverClass, $adapterConfig);
+
+        /** @var PlatformInterface $adapterPlatform */
+        $adapterPlatform = $container->build(PlatformInterface::class, ['driver' => $driver]);
+
+        /** @var ProfilerInterface|null $profilerInterface */
+        $profilerInterface = $container->has(ProfilerInterface::class)
+            ? $container->build(ProfilerInterface::class)
+            : null;
+
+        /** @var ResultSetInterface|null $queryResultSetPrototype */
+        $queryResultSetPrototype = $container->has(ResultSetInterface::class)
+            ? $container->get(ResultSetInterface::class)
+            : new ResultSet();
+
+        return new Adapter(
+            driver: $driver,
+            platform: $adapterPlatform,
+            queryResultSetPrototype: $queryResultSetPrototype,
+            profiler: $profilerInterface,
+        );
+    }
+}

--- a/test/unit/Adapter/Container/AdapterInterfaceDelegatorTest.php
+++ b/test/unit/Adapter/Container/AdapterInterfaceDelegatorTest.php
@@ -11,7 +11,7 @@ use PhpDb\Adapter\Adapter;
 use PhpDb\Adapter\AdapterInterface;
 use PhpDb\Adapter\Driver\DriverInterface;
 use PhpDb\Adapter\Platform\PlatformInterface;
-use PhpDb\Container\AdapterServiceDelegator;
+use PhpDb\Container\AdapterInterfaceDelegator;
 use PhpDb\Exception\RuntimeException;
 use PhpDb\ResultSet\ResultSetInterface;
 use PhpDbTest\Adapter\TestAsset\ConcreteAdapterAwareObject;
@@ -22,7 +22,7 @@ use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use stdClass;
 
-final class AdapterServiceDelegatorTest extends TestCase
+final class AdapterInterfaceDelegatorTest extends TestCase
 {
     /**
      * @throws Exception
@@ -44,7 +44,7 @@ final class AdapterServiceDelegatorTest extends TestCase
         $callback = static fn(): ConcreteAdapterAwareObject => new ConcreteAdapterAwareObject();
 
         /** @var ConcreteAdapterAwareObject $result */
-        $result = (new AdapterServiceDelegator())(
+        $result = (new AdapterInterfaceDelegator())(
             $container,
             ConcreteAdapterAwareObject::class,
             $callback
@@ -78,7 +78,7 @@ final class AdapterServiceDelegatorTest extends TestCase
         $callback = static fn(): ConcreteAdapterAwareObject => new ConcreteAdapterAwareObject();
 
         /** @var ConcreteAdapterAwareObject $result */
-        $result = (new AdapterServiceDelegator())(
+        $result = (new AdapterInterfaceDelegator())(
             $container,
             ConcreteAdapterAwareObject::class,
             $callback
@@ -110,7 +110,7 @@ final class AdapterServiceDelegatorTest extends TestCase
         $this->expectException(ServiceNotFoundException::class);
         $this->expectExceptionMessage('Service "PhpDb\Adapter\AdapterInterface" not found in container');
 
-        (new AdapterServiceDelegator())(
+        (new AdapterInterfaceDelegator())(
             $container,
             ConcreteAdapterAwareObject::class,
             $callback
@@ -134,7 +134,7 @@ final class AdapterServiceDelegatorTest extends TestCase
             'Delegated service "stdClass" must implement PhpDb\Adapter\AdapterAwareInterface'
         );
 
-        (new AdapterServiceDelegator())(
+        (new AdapterInterfaceDelegator())(
             $container,
             stdClass::class,
             $callback
@@ -163,7 +163,7 @@ final class AdapterServiceDelegatorTest extends TestCase
             ],
             'delegators' => [
                 ConcreteAdapterAwareObject::class => [
-                    AdapterServiceDelegator::class,
+                    AdapterInterfaceDelegator::class,
                 ],
             ],
         ]);
@@ -198,7 +198,7 @@ final class AdapterServiceDelegatorTest extends TestCase
             ],
             'delegators' => [
                 ConcreteAdapterAwareObject::class => [
-                    new AdapterServiceDelegator('alternate-database-adapter'),
+                    new AdapterInterfaceDelegator('alternate-database-adapter'),
                 ],
             ],
         ]);
@@ -236,7 +236,7 @@ final class AdapterServiceDelegatorTest extends TestCase
             ],
             'delegators' => [
                 ConcreteAdapterAwareObject::class => [
-                    AdapterServiceDelegator::class,
+                    AdapterInterfaceDelegator::class,
                 ],
             ],
         ];

--- a/test/unit/ConfigProviderTest.php
+++ b/test/unit/ConfigProviderTest.php
@@ -6,20 +6,31 @@ namespace PhpDbTest;
 
 use PhpDb\Adapter;
 use PhpDb\ConfigProvider;
-use PhpDb\Container\AbstractAdapterInterfaceFactory;
+use PhpDb\Container;
 use PHPUnit\Framework\TestCase;
 
 class ConfigProviderTest extends TestCase
 {
-    /** @phpstan-var array{'dependencies': array{abstract_factories: list<class-string>, aliases: array<class-string, class-string>}} */
+    /**
+     * @phpstan-var array{
+     *      'dependencies': array{
+     *          abstract_factories: list<class-string>,
+     *          aliases: array<class-string, class-string>,
+     *          factories: array<class-string, class-string>,
+     *      }
+     * }
+     * */
     private array $config = [
         Adapter\AdapterInterface::class => [],
         'dependencies'                  => [
             'abstract_factories' => [
-                AbstractAdapterInterfaceFactory::class,
+                Container\AbstractAdapterInterfaceFactory::class,
             ],
             'aliases'            => [
                 Adapter\AdapterInterface::class => Adapter\Adapter::class,
+            ],
+            'factories'          => [
+                Adapter\Adapter::class => Container\AdapterInterfaceFactory::class,
             ],
         ],
     ];


### PR DESCRIPTION
Updates existing test
Signed-off-by: Joey Smith <jsmith@webinertia.net>

Signed-off-by: Joey Smith <jsmith@webinertia.net>

<!--
Please fill in the relevant information below.

**Target Branch**
Given a current release of 1.0.0

The next patch release = 1.0.1
The next minor = 1.1.0
The next major = 2.0.0

The branching strategy is as follows: (these are the branch names that you will target your PRs to)
The Current release branch will be `1.0.x`
The next minor branch will be `1.1.x`
The next major branch will be `2.0.x`

Please target your pull request to the correct branch:
  * Documentation improvement: Current release branch
  * Bugfix: Current release branch
  * QA improvement (unit/integration tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.1.x
  * New feature/Refactor: Next minor 1.1.x
  * Any Backwards incompatible changes: Next major 2.0.x

You MUST provide a signoff in your commits for us to accept your
contribution/patch. You can do this by providing either the --signoff or -s flag when using
"git commit".
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes
| House Keeping | yes

### Description
This delegates Adapter creation back to the phpdb package.

Reason:
Due to the way ConfigAggregator works and laminas component installer we have no way to control the order in which the providers are written to the config array for Mezzio. Since this change unifies adapter creation for both standard adapter creation (single adapter) or Named adapter config and adapter packages are only providing the underlying dependency instances it will no longer matter which order the packages are listed as in the config.

Note:
All dependencies are aliased to their respective interfaces and each adapter will be expected to provide the required mapping for each Driver instance they expose. The creation context hinges on which Driver instance is passed in the adapters configuration.
<!--

Why is this changed needed?:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - Expected behavior
  - Current behavior
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding documentation?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you providing a QA improvement (unit/integration tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE NEXT MINOR BRANCH

- Are you fixing a BC Break? (Please open an issue first)
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding a new feature? (Please open an RFC first)
  - Why should it be added?
  - What are the potential use cases?
  - It must be documented.
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN

- Are you refactoring code?
  - Is it necessary?
  - What types of refactoring are you doing?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN
-->
