### PR TITLE
Add source directory configuration for coverage

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,12 @@
     failOnDeprecation="true"
     failOnWarning="true">
 
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+
     <testsuites>
         <testsuite name="unit test">
             <directory>./test/unit</directory>


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| House Keeping | yes

### Description

Add `<source>` to `phpunit.xml.dist` so `--coverage` doesn't moan with:

```
There was 1 PHPUnit test runner warning:

1) No filter is configured, code coverage will not be processed
```

There will be be around 65 PHPUnit warnings after this.