### PR TITLE
Fix bindParametersFromContainer() to prevent invalid parameter name characters

### DIFF
--- a/src/Adapter/Driver/Pdo/Statement.php
+++ b/src/Adapter/Driver/Pdo/Statement.php
@@ -22,6 +22,8 @@ use function implode;
 use function is_array;
 use function is_int;
 use function ltrim;
+use function preg_match;
+use function sprintf;
 
 class Statement implements StatementInterface, PdoDriverAwareInterface, ProfilerAwareInterface
 {
@@ -223,8 +225,19 @@ class Statement implements StatementInterface, PdoDriverAwareInterface, Profiler
                 };
             }
 
-            // parameter is named or positional, value is reference
-            $parameter = is_int($name) ? $name + 1 : ':' . ltrim($name, ':');
+            if (is_int($name)) {
+                $parameter = $name + 1;
+            } else {
+                if (! preg_match('/^:?[a-zA-Z0-9_]+$/', $name)) {
+                    throw new Exception\RuntimeException(sprintf(
+                        'The PDO param "%s" contains invalid characters.'
+                        . ' Only alphabetic characters, digits, and underscores (_) are allowed.',
+                        $name
+                    ));
+                }
+                $parameter = ':' . ltrim($name, ':');
+            }
+
             $this->resource->bindParam($parameter, $value, $type);
         }
 

--- a/test/unit/Adapter/Driver/Pdo/StatementTest.php
+++ b/test/unit/Adapter/Driver/Pdo/StatementTest.php
@@ -7,10 +7,12 @@ namespace PhpDbTest\Adapter\Driver\Pdo;
 use Override;
 use PhpDb\Adapter\Driver\Pdo\Result;
 use PhpDb\Adapter\Driver\Pdo\Statement;
+use PhpDb\Adapter\Exception\RuntimeException;
 use PhpDb\Adapter\ParameterContainer;
 use PhpDbTest\Adapter\Driver\Pdo\TestAsset\TestConnection;
 use PhpDbTest\Adapter\Driver\Pdo\TestAsset\TestPdo;
 use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversMethod(Statement::class, 'setDriver')]
@@ -22,6 +24,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversMethod(Statement::class, 'prepare')]
 #[CoversMethod(Statement::class, 'isPrepared')]
 #[CoversMethod(Statement::class, 'execute')]
+#[CoversMethod(Statement::class, 'bindParametersFromContainer')]
 final class StatementTest extends TestCase
 {
     protected Statement $statement;
@@ -110,5 +113,30 @@ final class StatementTest extends TestCase
         $this->statement->initialize($pdo);
         $this->statement->prepare('SELECT 1');
         self::assertInstanceOf(Result::class, $this->statement->execute());
+    }
+
+    /** @return array<string, array{string}> */
+    public static function invalidParameterNameProvider(): array
+    {
+        return [
+            'dollar sign' => ['tz$'],
+            'with colon'  => [':tz$'],
+            'hyphen'      => ['my-param'],
+            'space'       => ['my param'],
+            'dot'         => ['my.param'],
+            'at sign'     => ['param@name'],
+        ];
+    }
+
+    #[DataProvider('invalidParameterNameProvider')]
+    public function testExecuteThrowsOnInvalidParameterName(string $name): void
+    {
+        $this->statement->setDriver(new TestPdo(new TestConnection($pdo = new TestAsset\SqliteMemoryPdo())));
+        $this->statement->initialize($pdo);
+        $this->statement->prepare('SELECT 1');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('contains invalid characters');
+        $this->statement->execute([$name => 'value']);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes
| House Keeping | yes

### Description
A test from phpdb-mysql in `PhpDbIntegrationTest\Mysql\Pdo\QueryTest` called `testSelectWithNotPermittedBindParamName` was marked 'incomplete' but in reality it belongs in the core package.

The validation already exists in the vendor package at AbstractPdo::formatParameterName() (line 146: /[^a-zA-Z0-9_]/), but it's only called from the SQL builder path — never for raw queries.                                
                                                                                                                                                                                                                                                      
The problem is that the PDO Statement::bindParametersFromContainer() at src/Adapter/Driver/Pdo/Statement.php:227 constructs the parameter name and passes it straight to PDO::bindParam() without validating it. PDO silently accepts invalid characters like $.                                                                                                                                                                                                                  

This fixes the issue right within the Statement at bindParametersFromContainer just before the params hit the PDO resource.