### PR TITLE
Ddl improvements table

### DIFF
--- a/src/Sql/Ddl/AlterTable.php
+++ b/src/Sql/Ddl/AlterTable.php
@@ -10,6 +10,8 @@ use PhpDb\Sql\Literal;
 use PhpDb\Sql\TableIdentifier;
 
 use function array_key_exists;
+use function is_bool;
+use function is_int;
 use function strtoupper;
 
 class AlterTable extends AbstractSql

--- a/src/Sql/Ddl/AlterTable.php
+++ b/src/Sql/Ddl/AlterTable.php
@@ -6,9 +6,11 @@ namespace PhpDb\Sql\Ddl;
 
 use PhpDb\Adapter\Platform\PlatformInterface;
 use PhpDb\Sql\AbstractSql;
+use PhpDb\Sql\Literal;
 use PhpDb\Sql\TableIdentifier;
 
 use function array_key_exists;
+use function strtoupper;
 
 class AlterTable extends AbstractSql
 {
@@ -26,6 +28,8 @@ class AlterTable extends AbstractSql
 
     final public const TABLE = 'table';
 
+    final public const TABLE_OPTIONS = 'tableOptions';
+
     protected array $addColumns = [];
 
     protected array $addConstraints = [];
@@ -37,6 +41,8 @@ class AlterTable extends AbstractSql
     protected array $dropConstraints = [];
 
     protected array $dropIndexes = [];
+
+    protected array $options = [];
 
     /**
      * Specifications for Sql String generation
@@ -71,6 +77,11 @@ class AlterTable extends AbstractSql
         self::DROP_INDEXES     => [
             '%1$s' => [
                 [1 => "DROP INDEX %1\$s,\n", 'combinedby' => ''],
+            ],
+        ],
+        self::TABLE_OPTIONS    => [
+            "%1\$s" => [
+                [1 => "%1\$s,\n", 'combinedby' => ''],
             ],
         ],
     ];
@@ -136,6 +147,23 @@ class AlterTable extends AbstractSql
         return $this;
     }
 
+    public function setOption(string $name, Literal|bool|int|string $value): static
+    {
+        $this->options[$name] = $value;
+        return $this;
+    }
+
+    public function setOptions(array $options): static
+    {
+        $this->options = $options;
+        return $this;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
     public function getRawState(?string $key = null): array|string
     {
         $rawState = [
@@ -146,6 +174,7 @@ class AlterTable extends AbstractSql
             self::ADD_CONSTRAINTS  => $this->addConstraints,
             self::DROP_CONSTRAINTS => $this->dropConstraints,
             self::DROP_INDEXES     => $this->dropIndexes,
+            self::TABLE_OPTIONS    => $this->options,
         ];
 
         return isset($key) && array_key_exists($key, $rawState) ? $rawState[$key] : $rawState;
@@ -239,6 +268,33 @@ class AlterTable extends AbstractSql
         $sqls = [];
         foreach ($this->dropIndexes as $index) {
             $sqls[] = $adapterPlatform->quoteIdentifier($index);
+        }
+
+        return [$sqls];
+    }
+
+    /**
+     * @return string[][]|null
+     */
+    protected function processTableOptions(?PlatformInterface $adapterPlatform = null): ?array
+    {
+        if (! $this->options) {
+            return null;
+        }
+
+        $sqls = [];
+        foreach ($this->options as $key => $value) {
+            $key = strtoupper($key);
+            if ($value instanceof Literal) {
+                $value = $value->getLiteral();
+            } elseif (is_bool($value)) {
+                $value = $value ? '1' : '0';
+            } elseif (is_int($value)) {
+                $value = (string) $value;
+            } else {
+                $value = $adapterPlatform->quoteTrustedValue($value);
+            }
+            $sqls[] = $key . ' = ' . $value;
         }
 
         return [$sqls];

--- a/src/Sql/Ddl/CreateTable.php
+++ b/src/Sql/Ddl/CreateTable.php
@@ -10,6 +10,9 @@ use PhpDb\Sql\Literal;
 use PhpDb\Sql\TableIdentifier;
 
 use function array_key_exists;
+use function implode;
+use function is_bool;
+use function is_int;
 use function strtoupper;
 
 class CreateTable extends AbstractSql
@@ -36,19 +39,19 @@ class CreateTable extends AbstractSql
      * {@inheritDoc}
      */
     protected array $specifications = [
-        self::TABLE       => 'CREATE %1$sTABLE %2$s%3$s (',
-        self::COLUMNS     => [
+        self::TABLE         => 'CREATE %1$sTABLE %2$s%3$s (',
+        self::COLUMNS       => [
             "\n    %1\$s" => [
                 [1 => '%1$s', 'combinedby' => ",\n    "],
             ],
         ],
-        'combinedBy'      => ',',
-        self::CONSTRAINTS => [
+        'combinedBy'        => ',',
+        self::CONSTRAINTS   => [
             "\n    %1\$s" => [
                 [1 => '%1$s', 'combinedby' => ",\n    "],
             ],
         ],
-        'statementEnd'    => '%1$s',
+        'statementEnd'      => '%1$s',
         self::TABLE_OPTIONS => '%1$s',
     ];
 

--- a/src/Sql/Ddl/CreateTable.php
+++ b/src/Sql/Ddl/CreateTable.php
@@ -6,9 +6,11 @@ namespace PhpDb\Sql\Ddl;
 
 use PhpDb\Adapter\Platform\PlatformInterface;
 use PhpDb\Sql\AbstractSql;
+use PhpDb\Sql\Literal;
 use PhpDb\Sql\TableIdentifier;
 
 use function array_key_exists;
+use function strtoupper;
 
 class CreateTable extends AbstractSql
 {
@@ -18,11 +20,15 @@ class CreateTable extends AbstractSql
 
     final public const TABLE = 'table';
 
+    final public const TABLE_OPTIONS = 'tableOptions';
+
     protected array $columns = [];
 
     protected array $constraints = [];
 
     protected bool $isTemporary = false;
+
+    protected array $options = [];
 
     /**
      * {@inheritDoc}
@@ -41,6 +47,7 @@ class CreateTable extends AbstractSql
             ],
         ],
         'statementEnd'    => '%1$s',
+        self::TABLE_OPTIONS => '%1$s',
     ];
 
     protected string|TableIdentifier $table = '';
@@ -80,6 +87,23 @@ class CreateTable extends AbstractSql
         return $this;
     }
 
+    public function setOption(string $name, Literal|bool|int|string $value): static
+    {
+        $this->options[$name] = $value;
+        return $this;
+    }
+
+    public function setOptions(array $options): static
+    {
+        $this->options = $options;
+        return $this;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
     /**
      * @return ((Column\ColumnInterface|string)[]|Column\ColumnInterface|string)[]|string
      * @psalm-return array<Column\ColumnInterface|array<Column\ColumnInterface|string>|string>|string
@@ -87,9 +111,10 @@ class CreateTable extends AbstractSql
     public function getRawState(?string $key = null): array|string
     {
         $rawState = [
-            self::COLUMNS     => $this->columns,
-            self::CONSTRAINTS => $this->constraints,
-            self::TABLE       => $this->table,
+            self::COLUMNS       => $this->columns,
+            self::CONSTRAINTS   => $this->constraints,
+            self::TABLE         => $this->table,
+            self::TABLE_OPTIONS => $this->options,
         ];
 
         return isset($key) && array_key_exists($key, $rawState) ? $rawState[$key] : $rawState;
@@ -157,5 +182,32 @@ class CreateTable extends AbstractSql
     protected function processStatementEnd(?PlatformInterface $adapterPlatform = null): array
     {
         return ["\n)"];
+    }
+
+    /**
+     * @return string[]|null
+     */
+    protected function processTableOptions(?PlatformInterface $adapterPlatform = null): ?array
+    {
+        if (! $this->options) {
+            return null;
+        }
+
+        $parts = [];
+        foreach ($this->options as $key => $value) {
+            $key = strtoupper($key);
+            if ($value instanceof Literal) {
+                $value = $value->getLiteral();
+            } elseif (is_bool($value)) {
+                $value = $value ? '1' : '0';
+            } elseif (is_int($value)) {
+                $value = (string) $value;
+            } else {
+                $value = $adapterPlatform->quoteTrustedValue($value);
+            }
+            $parts[] = $key . ' = ' . $value;
+        }
+
+        return [implode(' ', $parts)];
     }
 }

--- a/test/unit/Sql/Ddl/AlterTableTest.php
+++ b/test/unit/Sql/Ddl/AlterTableTest.php
@@ -9,6 +9,7 @@ use PhpDb\Sql\Ddl\Column;
 use PhpDb\Sql\Ddl\Column\ColumnInterface;
 use PhpDb\Sql\Ddl\Constraint;
 use PhpDb\Sql\Ddl\Constraint\ConstraintInterface;
+use PhpDb\Sql\Literal;
 use PhpDb\Sql\TableIdentifier;
 use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\TestCase;
@@ -31,6 +32,10 @@ use function str_replace;
 #[CoversMethod(AlterTable::class, 'processAddConstraints')]
 #[CoversMethod(AlterTable::class, 'processDropConstraints')]
 #[CoversMethod(AlterTable::class, 'processDropIndexes')]
+#[CoversMethod(AlterTable::class, 'setOption')]
+#[CoversMethod(AlterTable::class, 'setOptions')]
+#[CoversMethod(AlterTable::class, 'getOptions')]
+#[CoversMethod(AlterTable::class, 'processTableOptions')]
 class AlterTableTest extends TestCase
 {
     public function testSetTable(): void
@@ -345,5 +350,100 @@ EOS;
         $sql = $at->getSqlString();
         self::assertStringContainsString('"schema"."table"', $sql);
         self::assertStringContainsString('CHANGE COLUMN "col1" "col1_new"', $sql);
+    }
+
+    public function testSetOptionFluentInterface(): void
+    {
+        $at     = new AlterTable('foo');
+        $result = $at->setOption('engine', new Literal('InnoDB'));
+
+        self::assertSame($at, $result);
+        self::assertEquals(['engine' => new Literal('InnoDB')], $at->getOptions());
+    }
+
+    public function testSetOptionsReplacesAll(): void
+    {
+        $at = new AlterTable('foo');
+        $at->setOption('engine', new Literal('InnoDB'));
+
+        $at->setOptions(['charset' => new Literal('utf8mb4')]);
+
+        self::assertEquals(['charset' => new Literal('utf8mb4')], $at->getOptions());
+    }
+
+    public function testGetOptionsReturnsEmpty(): void
+    {
+        $at = new AlterTable('foo');
+        self::assertEquals([], $at->getOptions());
+    }
+
+    public function testGetRawStateIncludesTableOptions(): void
+    {
+        $at = new AlterTable('foo');
+        $at->setOption('engine', new Literal('InnoDB'));
+
+        $rawState = $at->getRawState();
+
+        self::assertArrayHasKey(AlterTable::TABLE_OPTIONS, $rawState);
+        self::assertEquals(['engine' => new Literal('InnoDB')], $rawState[AlterTable::TABLE_OPTIONS]);
+    }
+
+    public function testGetSqlStringWithEngineOption(): void
+    {
+        $at = new AlterTable('foo');
+        $at->setOption('engine', new Literal('InnoDB'));
+
+        $sql = $at->getSqlString();
+        self::assertStringContainsString('ALTER TABLE "foo"', $sql);
+        self::assertStringContainsString('ENGINE = InnoDB', $sql);
+    }
+
+    public function testGetSqlStringWithColumnAndEngineOption(): void
+    {
+        $at = new AlterTable('foo');
+        $at->addColumn(new Column\Column('bar'));
+        $at->setOption('engine', new Literal('InnoDB'));
+
+        $sql = $at->getSqlString();
+        self::assertStringContainsString('ADD COLUMN "bar" INTEGER NOT NULL', $sql);
+        self::assertStringContainsString('ENGINE = InnoDB', $sql);
+    }
+
+    public function testGetSqlStringWithStringOption(): void
+    {
+        $at = new AlterTable('foo');
+        $at->setOption('comment', 'My table');
+
+        $sql = $at->getSqlString();
+        self::assertStringContainsString('COMMENT = \'My table\'', $sql);
+    }
+
+    public function testGetSqlStringWithIntOption(): void
+    {
+        $at = new AlterTable('foo');
+        $at->setOption('auto_increment', 100);
+
+        $sql = $at->getSqlString();
+        self::assertStringContainsString('AUTO_INCREMENT = 100', $sql);
+    }
+
+    public function testGetSqlStringWithBoolOption(): void
+    {
+        $at = new AlterTable('foo');
+        $at->setOption('pack_keys', true);
+
+        $sql = $at->getSqlString();
+        self::assertStringContainsString('PACK_KEYS = 1', $sql);
+    }
+
+    public function testGetSqlStringWithMultipleOptions(): void
+    {
+        $at = new AlterTable('foo');
+        $at->setOption('engine', new Literal('InnoDB'));
+        $at->setOption('auto_increment', 100);
+
+        $sql = $at->getSqlString();
+        self::assertStringContainsString('ENGINE = InnoDB', $sql);
+        self::assertStringContainsString('AUTO_INCREMENT = 100', $sql);
     }
 }

--- a/test/unit/Sql/Ddl/CreateTableTest.php
+++ b/test/unit/Sql/Ddl/CreateTableTest.php
@@ -9,6 +9,7 @@ use PhpDb\Sql\Ddl\Column\ColumnInterface;
 use PhpDb\Sql\Ddl\Constraint;
 use PhpDb\Sql\Ddl\Constraint\ConstraintInterface;
 use PhpDb\Sql\Ddl\CreateTable;
+use PhpDb\Sql\Literal;
 use PhpDb\Sql\TableIdentifier;
 use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\TestCase;
@@ -26,6 +27,10 @@ use PHPUnit\Framework\TestCase;
 #[CoversMethod(CreateTable::class, 'processCombinedby')]
 #[CoversMethod(CreateTable::class, 'processConstraints')]
 #[CoversMethod(CreateTable::class, 'processStatementEnd')]
+#[CoversMethod(CreateTable::class, 'setOption')]
+#[CoversMethod(CreateTable::class, 'setOptions')]
+#[CoversMethod(CreateTable::class, 'getOptions')]
+#[CoversMethod(CreateTable::class, 'processTableOptions')]
 class CreateTableTest extends TestCase
 {
     /**
@@ -307,5 +312,113 @@ class CreateTableTest extends TestCase
         $result = $ct->setTable('another_table');
         self::assertSame($ct, $result);
         self::assertEquals('another_table', $ct->getRawState(CreateTable::TABLE));
+    }
+
+    public function testSetOptionFluentInterface(): void
+    {
+        $ct     = new CreateTable('foo');
+        $result = $ct->setOption('engine', new Literal('InnoDB'));
+
+        self::assertSame($ct, $result);
+        self::assertEquals(['engine' => new Literal('InnoDB')], $ct->getOptions());
+    }
+
+    public function testSetOptionsReplacesAll(): void
+    {
+        $ct = new CreateTable('foo');
+        $ct->setOption('engine', new Literal('InnoDB'));
+
+        $ct->setOptions(['charset' => new Literal('utf8mb4')]);
+
+        self::assertEquals(['charset' => new Literal('utf8mb4')], $ct->getOptions());
+    }
+
+    public function testGetOptionsReturnsEmpty(): void
+    {
+        $ct = new CreateTable('foo');
+        self::assertEquals([], $ct->getOptions());
+    }
+
+    public function testGetRawStateIncludesTableOptions(): void
+    {
+        $ct = new CreateTable('foo');
+        $ct->setOption('engine', new Literal('InnoDB'));
+
+        $rawState = $ct->getRawState();
+
+        self::assertArrayHasKey(CreateTable::TABLE_OPTIONS, $rawState);
+        self::assertEquals(['engine' => new Literal('InnoDB')], $rawState[CreateTable::TABLE_OPTIONS]);
+    }
+
+    public function testGetSqlStringWithLiteralOption(): void
+    {
+        $ct = new CreateTable('foo');
+        $ct->addColumn(new Column('bar'));
+        $ct->setOption('engine', new Literal('InnoDB'));
+
+        self::assertEquals(
+            "CREATE TABLE \"foo\" ( \n    \"bar\" INTEGER NOT NULL \n) ENGINE = InnoDB",
+            $ct->getSqlString()
+        );
+    }
+
+    public function testGetSqlStringWithStringOption(): void
+    {
+        $ct = new CreateTable('foo');
+        $ct->addColumn(new Column('bar'));
+        $ct->setOption('comment', 'My table');
+
+        self::assertEquals(
+            "CREATE TABLE \"foo\" ( \n    \"bar\" INTEGER NOT NULL \n) COMMENT = 'My table'",
+            $ct->getSqlString()
+        );
+    }
+
+    public function testGetSqlStringWithIntOption(): void
+    {
+        $ct = new CreateTable('foo');
+        $ct->addColumn(new Column('bar'));
+        $ct->setOption('auto_increment', 100);
+
+        self::assertEquals(
+            "CREATE TABLE \"foo\" ( \n    \"bar\" INTEGER NOT NULL \n) AUTO_INCREMENT = 100",
+            $ct->getSqlString()
+        );
+    }
+
+    public function testGetSqlStringWithBoolOption(): void
+    {
+        $ct = new CreateTable('foo');
+        $ct->addColumn(new Column('bar'));
+        $ct->setOption('pack_keys', true);
+
+        self::assertEquals(
+            "CREATE TABLE \"foo\" ( \n    \"bar\" INTEGER NOT NULL \n) PACK_KEYS = 1",
+            $ct->getSqlString()
+        );
+    }
+
+    public function testGetSqlStringWithMultipleOptions(): void
+    {
+        $ct = new CreateTable('foo');
+        $ct->addColumn(new Column('bar'));
+        $ct->setOption('engine', new Literal('InnoDB'));
+        $ct->setOption('auto_increment', 100);
+
+        self::assertEquals(
+            "CREATE TABLE \"foo\" ( \n    \"bar\" INTEGER NOT NULL \n) ENGINE = InnoDB AUTO_INCREMENT = 100",
+            $ct->getSqlString()
+        );
+    }
+
+    public function testGetSqlStringWithNoOptionsUnchanged(): void
+    {
+        $ct = new CreateTable('foo');
+        $ct->addColumn(new Column('bar'));
+
+        self::assertEquals(
+            "CREATE TABLE \"foo\" ( \n    \"bar\" INTEGER NOT NULL \n)",
+            $ct->getSqlString()
+        );
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes
| House Keeping | yes

### Description
This improvement adds the ability to set options to the ALTER and CREATE Table DDL statements, allowing per-table options like ENGINE, comments, character sets etc...