### PR TITLE
Nullable columns now output NULL DEFAULT NULL in DDL

### DIFF
--- a/src/Sql/Ddl/Column/Column.php
+++ b/src/Sql/Ddl/Column/Column.php
@@ -115,6 +115,8 @@ class Column implements ColumnInterface
 
         if ($this->isNullable === false) {
             $specParts[] = 'NOT NULL';
+        } else {
+            $specParts[] = 'NULL';
         }
 
         if ($this->default !== null) {
@@ -122,6 +124,8 @@ class Column implements ColumnInterface
             $values[]    = $this->default instanceof ArgumentInterface
                 ? $this->default
                 : new Value($this->default);
+        } elseif ($this->isNullable) {
+            $specParts[] = 'DEFAULT NULL';
         }
 
         foreach ($this->constraints as $constraint) {

--- a/test/unit/Sql/Ddl/Column/ColumnTest.php
+++ b/test/unit/Sql/Ddl/Column/ColumnTest.php
@@ -151,7 +151,7 @@ final class ColumnTest extends TestCase
 
         $expressionData = $column->getExpressionData();
 
-        self::assertEquals('%s %s', $expressionData['spec']);
+        self::assertEquals('%s %s NULL DEFAULT NULL', $expressionData['spec']);
         self::assertEquals([
             Argument::identifier('foo'),
             Argument::literal('INTEGER'),
@@ -161,7 +161,7 @@ final class ColumnTest extends TestCase
 
         $expressionData = $column->getExpressionData();
 
-        self::assertEquals('%s %s DEFAULT %s', $expressionData['spec']);
+        self::assertEquals('%s %s NULL DEFAULT %s', $expressionData['spec']);
         self::assertEquals([
             Argument::identifier('foo'),
             Argument::literal('INTEGER'),


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes
| House Keeping | no

When a column is nullable and no explicit default is set, the generated SQL now includes NULL DEFAULT NULL instead of omitting both keywords. 

Fixes #140.
