### PR TITLE
Narrow Join::join() $columns parameter to array|string

### DIFF
--- a/src/Sql/Join.php
+++ b/src/Sql/Join.php
@@ -111,7 +111,7 @@ class Join implements Iterator, Countable
      * @param array|string|TableIdentifier $name    A table name on which to join, or a single
      *     element associative array, of the form alias => table, or TableIdentifier instance
      * @param string|Predicate\Expression  $on      A specification describing the fields to join on.
-     * @param int|string|int[]|string[]    $columns A single column name, an array
+     * @param string|string[]              $columns A single column name, an array
      *     of column names, or (a) specification(s) such as SQL_STAR representing
      *     the columns to join.
      * @param string                       $type    The JOIN type to use; see the JOIN_* constants.
@@ -121,7 +121,7 @@ class Join implements Iterator, Countable
     public function join(
         array|string|TableIdentifier $name,
         string|Predicate\PredicateInterface $on,
-        array|int|string $columns = [Select::SQL_STAR],
+        array|string $columns = [Select::SQL_STAR],
         string $type = self::JOIN_INNER
     ): static {
         if (is_array($name) && (! is_string(key($name)) || count($name) !== 1)) {


### PR DESCRIPTION
Fixes #154

Removes `int` from the accepted types for the `$columns` parameter of `Join::join()`, narrowing the signature from `array|int|string` to `array|string`. 
