### PR TITLE
Split ResultSetInterface into capability interfaces

### DIFF
--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -17,10 +17,7 @@ use ReturnTypeWillChange;
 
 use function count;
 use function current;
-use function gettype;
 use function is_array;
-use function is_object;
-use function method_exists;
 use function reset;
 
 abstract class AbstractResultSet implements ResultSetInterface
@@ -41,6 +38,106 @@ abstract class AbstractResultSet implements ResultSetInterface
     protected ?int $fieldCount = null;
 
     protected int $position = 0;
+
+    /**
+     * @throws RuntimeException
+     */
+    public function buffer(): ResultSetInterface
+    {
+        if ($this->buffer === -2) {
+            throw new RuntimeException('Buffering must be enabled before iteration is started');
+        } elseif ($this->buffer === null) {
+            $this->buffer = [];
+            if ($this->dataSource instanceof ResultInterface) {
+                $this->dataSource->rewind();
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Countable: return count of rows
+     */
+    #[Override]
+    #[ReturnTypeWillChange]
+    public function count(): ?int
+    {
+        if ($this->count !== null) {
+            return $this->count;
+        }
+
+        if ($this->dataSource instanceof Countable) {
+            $this->count = count($this->dataSource);
+        }
+
+        return $this->count;
+    }
+
+    /**
+     * Iterator: get current item
+     */
+    #[Override]
+    public function current(): array|object|null
+    {
+        if (-1 === $this->buffer) {
+            // datasource was an array when the resultset was initialized
+            return $this->dataSource->current();
+        }
+
+        if ($this->buffer === null) {
+            $this->buffer = -2; // implicitly disable buffering from here on
+        } elseif (is_array($this->buffer) && isset($this->buffer[$this->position])) {
+            return $this->buffer[$this->position];
+        }
+
+        $data = $this->dataSource->current();
+        if (is_array($this->buffer)) {
+            $this->buffer[$this->position] = $data;
+        }
+
+        return is_array($data) ? $data : null;
+    }
+
+    /**
+     * Get the data source used to create the result set
+     */
+    public function getDataSource(): ResultInterface|IteratorAggregate|Iterator|null
+    {
+        return $this->dataSource;
+    }
+
+    /**
+     * Retrieve count of fields in individual rows of the result set
+     */
+    #[Override]
+    public function getFieldCount(): int
+    {
+        if (null !== $this->fieldCount) {
+            return $this->fieldCount;
+        }
+
+        $dataSource = $this->getDataSource();
+        if (null === $dataSource) {
+            return 0;
+        }
+
+        $dataSource->rewind();
+        if (! $dataSource->valid()) {
+            $this->fieldCount = 0;
+            return 0;
+        }
+
+        $row = $dataSource->current();
+        if ($row instanceof Countable) {
+            $this->fieldCount = $row->count();
+            return $this->fieldCount;
+        }
+
+        $row              = (array) $row;
+        $this->fieldCount = count($row);
+        return $this->fieldCount;
+    }
 
     /**
      * Set the data source for the result set
@@ -87,66 +184,18 @@ abstract class AbstractResultSet implements ResultSetInterface
         return $this;
     }
 
-    /**
-     * @throws RuntimeException
-     */
-    public function buffer(): ResultSetInterface
-    {
-        if ($this->buffer === -2) {
-            throw new RuntimeException('Buffering must be enabled before iteration is started');
-        } elseif ($this->buffer === null) {
-            $this->buffer = [];
-            if ($this->dataSource instanceof ResultInterface) {
-                $this->dataSource->rewind();
-            }
-        }
-
-        return $this;
-    }
-
     public function isBuffered(): bool
     {
         return $this->buffer === -1 || is_array($this->buffer);
     }
 
     /**
-     * Get the data source used to create the result set
-     */
-    public function getDataSource(): ResultInterface|IteratorAggregate|Iterator|null
-    {
-        return $this->dataSource;
-    }
-
-    /**
-     * Retrieve count of fields in individual rows of the result set
+     * Iterator: retrieve current key
      */
     #[Override]
-    public function getFieldCount(): int
+    public function key(): int
     {
-        if (null !== $this->fieldCount) {
-            return $this->fieldCount;
-        }
-
-        $dataSource = $this->getDataSource();
-        if (null === $dataSource) {
-            return 0;
-        }
-
-        $dataSource->rewind();
-        if (! $dataSource->valid()) {
-            $this->fieldCount = 0;
-            return 0;
-        }
-
-        $row = $dataSource->current();
-        if ($row instanceof Countable) {
-            $this->fieldCount = $row->count();
-            return $this->fieldCount;
-        }
-
-        $row              = (array) $row;
-        $this->fieldCount = count($row);
-        return $this->fieldCount;
+        return $this->position;
     }
 
     /**
@@ -167,53 +216,6 @@ abstract class AbstractResultSet implements ResultSetInterface
     }
 
     /**
-     * Iterator: retrieve current key
-     */
-    #[Override]
-    public function key(): int
-    {
-        return $this->position;
-    }
-
-    /**
-     * Iterator: get current item
-     */
-    #[Override]
-    public function current(): array|object|null
-    {
-        if (-1 === $this->buffer) {
-            // datasource was an array when the resultset was initialized
-            return $this->dataSource->current();
-        }
-
-        if ($this->buffer === null) {
-            $this->buffer = -2; // implicitly disable buffering from here on
-        } elseif (is_array($this->buffer) && isset($this->buffer[$this->position])) {
-            return $this->buffer[$this->position];
-        }
-
-        $data = $this->dataSource->current();
-        if (is_array($this->buffer)) {
-            $this->buffer[$this->position] = $data;
-        }
-
-        return is_array($data) ? $data : null;
-    }
-
-    /**
-     * Iterator: is pointer valid?
-     */
-    #[Override]
-    public function valid(): bool
-    {
-        if (is_array($this->buffer) && isset($this->buffer[$this->position])) {
-            return true;
-        }
-
-        return $this->dataSource->valid();
-    }
-
-    /**
      * Iterator: rewind
      */
     #[Override]
@@ -227,53 +229,15 @@ abstract class AbstractResultSet implements ResultSetInterface
     }
 
     /**
-     * Countable: return count of rows
+     * Iterator: is pointer valid?
      */
     #[Override]
-    #[ReturnTypeWillChange]
-    public function count(): ?int
+    public function valid(): bool
     {
-        if ($this->count !== null) {
-            return $this->count;
+        if (is_array($this->buffer) && isset($this->buffer[$this->position])) {
+            return true;
         }
 
-        if ($this->dataSource instanceof Countable) {
-            $this->count = count($this->dataSource);
-        }
-
-        return $this->count;
-    }
-
-    /**
-     * Cast result set to array of arrays
-     *
-     * @throws RuntimeException If any row is not castable to an array.
-     */
-    #[Override]
-    public function toArray(): array
-    {
-        $return = [];
-        foreach ($this as $row) {
-            if (is_array($row)) {
-                $return[] = $row;
-                continue;
-            }
-
-            if (
-                ! is_object($row)
-                || (
-                    ! method_exists($row, 'toArray')
-                    && ! method_exists($row, 'getArrayCopy')
-                )
-            ) {
-                throw new RuntimeException(
-                    'Rows as part of this DataSource, with type ' . gettype($row) . ' cannot be cast to an array'
-                );
-            }
-
-            $return[] = method_exists($row, 'toArray') ? $row->toArray() : $row->getArrayCopy();
-        }
-
-        return $return;
+        return $this->dataSource->valid();
     }
 }

--- a/src/ResultSet/ArrayObjectResultSetInterface.php
+++ b/src/ResultSet/ArrayObjectResultSetInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDb\ResultSet;
+
+use ArrayObject;
+
+/**
+ * Capability interface for a ResultSet whose rows clone an ArrayObject prototype.
+ */
+interface ArrayObjectResultSetInterface
+{
+    public function getRowPrototype(): ArrayObject;
+
+    public function setRowPrototype(ArrayObject $rowPrototype): ResultSetInterface&ArrayObjectResultSetInterface;
+}

--- a/src/ResultSet/Exception/ExceptionInterface.php
+++ b/src/ResultSet/Exception/ExceptionInterface.php
@@ -6,6 +6,4 @@ namespace PhpDb\ResultSet\Exception;
 
 use PhpDb\Exception;
 
-interface ExceptionInterface extends Exception\ExceptionInterface
-{
-}
+interface ExceptionInterface extends Exception\ExceptionInterface {}

--- a/src/ResultSet/Exception/InvalidArgumentException.php
+++ b/src/ResultSet/Exception/InvalidArgumentException.php
@@ -6,6 +6,4 @@ namespace PhpDb\ResultSet\Exception;
 
 use PhpDb\Exception;
 
-class InvalidArgumentException extends Exception\InvalidArgumentException implements ExceptionInterface
-{
-}
+class InvalidArgumentException extends Exception\InvalidArgumentException implements ExceptionInterface {}

--- a/src/ResultSet/Exception/RuntimeException.php
+++ b/src/ResultSet/Exception/RuntimeException.php
@@ -6,6 +6,4 @@ namespace PhpDb\ResultSet\Exception;
 
 use PhpDb\Exception;
 
-class RuntimeException extends Exception\RuntimeException implements ExceptionInterface
-{
-}
+class RuntimeException extends Exception\RuntimeException implements ExceptionInterface {}

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -11,57 +11,12 @@ use Override;
 
 use function is_array;
 
-class HydratingResultSet extends AbstractResultSet
+class HydratingResultSet extends AbstractResultSet implements HydratingResultSetInterface
 {
     public function __construct(
         private ?HydratorInterface $hydrator = null,
-        private ?object $rowPrototype = null
-    ) {
-    }
-
-    /**
-     * Set the hydrator to use for each row object
-     */
-    public function setHydrator(HydratorInterface $hydrator): ResultSetInterface
-    {
-        $this->hydrator = $hydrator;
-        return $this;
-    }
-
-    /**
-     * Get the hydrator to use for each row object
-     */
-    public function getHydrator(): HydratorInterface
-    {
-        return $this->hydrator ??= new ArraySerializableHydrator();
-    }
-
-    /** {@inheritDoc} */
-    #[Override]
-    public function setRowPrototype(object $rowPrototype): ResultSetInterface
-    {
-        $this->rowPrototype = $rowPrototype;
-        return $this;
-    }
-
-    /** {@inheritDoc} */
-    #[Override]
-    public function getRowPrototype(): object
-    {
-        return $this->rowPrototype ??= new ArrayObject();
-    }
-
-    /** @deprecated use setRowPrototype() */
-    public function setObjectPrototype(object $objectPrototype): ResultSetInterface
-    {
-        return $this->setRowPrototype($objectPrototype);
-    }
-
-    /** @deprecated use getRowPrototype() */
-    public function getObjectPrototype(): ?object
-    {
-        return $this->getRowPrototype();
-    }
+        private ?object $rowPrototype = null,
+    ) {}
 
     /**
      * Iterator: get current item
@@ -82,6 +37,50 @@ class HydratingResultSet extends AbstractResultSet
         }
 
         return $current;
+    }
+
+    /**
+     * Get the hydrator to use for each row object
+     */
+    public function getHydrator(): HydratorInterface
+    {
+        return $this->hydrator ??= new ArraySerializableHydrator();
+    }
+
+    /** @deprecated use getRowPrototype() */
+    public function getObjectPrototype(): ?object
+    {
+        return $this->getRowPrototype();
+    }
+
+    /** {@inheritDoc} */
+    #[Override]
+    public function getRowPrototype(): object
+    {
+        return $this->rowPrototype ??= new ArrayObject();
+    }
+
+    /**
+     * Set the hydrator to use for each row object
+     */
+    public function setHydrator(HydratorInterface $hydrator): ResultSetInterface
+    {
+        $this->hydrator = $hydrator;
+        return $this;
+    }
+
+    /** @deprecated use setRowPrototype() */
+    public function setObjectPrototype(object $objectPrototype): ResultSetInterface
+    {
+        return $this->setRowPrototype($objectPrototype);
+    }
+
+    /** {@inheritDoc} */
+    #[Override]
+    public function setRowPrototype(object $rowPrototype): ResultSetInterface&HydratingResultSetInterface
+    {
+        $this->rowPrototype = $rowPrototype;
+        return $this;
     }
 
     /**

--- a/src/ResultSet/HydratingResultSetInterface.php
+++ b/src/ResultSet/HydratingResultSetInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDb\ResultSet;
+
+/**
+ * Capability interface for a ResultSet whose rows are hydrated onto an arbitrary object prototype.
+ */
+interface HydratingResultSetInterface
+{
+    public function getRowPrototype(): object;
+
+    public function setRowPrototype(object $rowPrototype): ResultSetInterface&HydratingResultSetInterface;
+}

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -10,7 +10,7 @@ use Override;
 use function is_array;
 use function is_string;
 
-class ResultSet extends AbstractResultSet
+class ResultSet extends AbstractResultSet implements ArrayObjectResultSetInterface
 {
     /** @deprecated use ResultSetReturnType */
     public const TYPE_ARRAYOBJECT = 'arrayobject';
@@ -18,45 +18,21 @@ class ResultSet extends AbstractResultSet
 
     public function __construct(
         private ResultSetReturnType|string $returnType = ResultSetReturnType::ArrayObject,
-        private ArrayObject|RowPrototypeInterface|null $rowPrototype = new ArrayObject(
+        private ArrayObject $rowPrototype = new ArrayObject(
             [],
-            ArrayObject::ARRAY_AS_PROPS
-        )
+            ArrayObject::ARRAY_AS_PROPS,
+        ),
     ) {
         if (is_string($this->returnType)) {
             $this->returnType = ResultSetReturnType::from($this->returnType);
         }
     }
 
-    /** {@inheritDoc} */
-    #[Override]
-    public function setRowPrototype(ArrayObject|RowPrototypeInterface $rowPrototype): ResultSetInterface
-    {
-        $this->rowPrototype = $rowPrototype;
-
-        return $this;
-    }
-
-    /** {@inheritDoc} */
-    #[Override]
-    public function getRowPrototype(): ArrayObject|RowPrototypeInterface
-    {
-        return $this->rowPrototype;
-    }
-
-    /**
-     * Get the return type to use when returning objects from the set
-     */
-    public function getReturnType(): ResultSetReturnType
-    {
-        return $this->returnType;
-    }
-
     /**
      * Iterator: get current item
      */
     #[Override]
-    public function current(): array|ArrayObject|RowPrototypeInterface|null
+    public function current(): array|ArrayObject|null
     {
         $data = parent::current();
 
@@ -71,20 +47,56 @@ class ResultSet extends AbstractResultSet
     }
 
     /**
+     * @deprecated use getRowPrototype()
+     */
+    public function getArrayObjectPrototype(): ArrayObject
+    {
+        return $this->getRowPrototype();
+    }
+
+    /**
+     * Get the return type to use when returning objects from the set
+     */
+    public function getReturnType(): ResultSetReturnType
+    {
+        return $this->returnType;
+    }
+
+    /** {@inheritDoc} */
+    #[Override]
+    public function getRowPrototype(): ArrayObject
+    {
+        return $this->rowPrototype;
+    }
+
+    /**
      * Set the row object prototype
      *
      * @deprecated use setRowPrototype()
      */
-    public function setArrayObjectPrototype(ArrayObject|RowPrototypeInterface $arrayObjectPrototype): ResultSetInterface
+    public function setArrayObjectPrototype(ArrayObject $arrayObjectPrototype): ResultSetInterface&ArrayObjectResultSetInterface
     {
         return $this->setRowPrototype($arrayObjectPrototype);
     }
 
-    /**
-     * @deprecated use getRowPrototype()
-     */
-    public function getArrayObjectPrototype(): ArrayObject|RowPrototypeInterface
+    /** {@inheritDoc} */
+    #[Override]
+    public function setRowPrototype(ArrayObject $rowPrototype): ResultSetInterface&ArrayObjectResultSetInterface
     {
-        return $this->getRowPrototype();
+        $this->rowPrototype = $rowPrototype;
+
+        return $this;
+    }
+
+    /** {@inheritDoc} */
+    #[Override]
+    public function toArray(): array
+    {
+        $return = [];
+        foreach ($this as $row) {
+            $return[] = $row instanceof ArrayObject ? $row->getArrayCopy() : $row;
+        }
+
+        return $return;
     }
 }

--- a/src/ResultSet/ResultSetInterface.php
+++ b/src/ResultSet/ResultSetInterface.php
@@ -4,17 +4,11 @@ declare(strict_types=1);
 
 namespace PhpDb\ResultSet;
 
-use ArrayObject;
 use Countable;
 use Iterator;
 
 interface ResultSetInterface extends Iterator, Countable
 {
-    /**
-     * Can be anything iterable|array
-     */
-    public function initialize(iterable $dataSource): ResultSetInterface;
-
     /**
      * Field terminology is more correct as information coming back
      * from the database might be a column, and/or the result of an
@@ -23,21 +17,12 @@ interface ResultSetInterface extends Iterator, Countable
     public function getFieldCount(): int;
 
     /**
-     * Set the row object prototype
-     *
-     * @throws Exception\InvalidArgumentException
+     * Can be anything iterable|array
      */
-    public function setRowPrototype(ArrayObject|RowPrototypeInterface $rowPrototype): ResultSetInterface;
-
-    /**
-     * Get the row object prototype
-     */
-    public function getRowPrototype(): ?object;
+    public function initialize(iterable $dataSource): ResultSetInterface;
 
     /**
      * Get all rows as an array
-     *
-     * @return RowPrototypeInterface[]|ArrayObject[]|array[]
      */
     public function toArray(): array;
 }

--- a/test/unit/ResultSet/AbstractResultSetIntegrationTest.php
+++ b/test/unit/ResultSet/AbstractResultSetIntegrationTest.php
@@ -18,20 +18,6 @@ final class AbstractResultSetIntegrationTest extends TestCase
     protected MockObject|AbstractResultSet $resultSet;
 
     /**
-     * Sets up the fixture, for example, opens a network connection.
-     * This method is called before a test is executed.
-     *
-     * @throws Exception
-     */
-    #[Override]
-    protected function setUp(): void
-    {
-        $this->resultSet = $this->getMockBuilder(AbstractResultSet::class)
-            ->onlyMethods(['setRowPrototype', 'getRowPrototype'])
-            ->getMock();
-    }
-
-    /**
      * @throws \Exception
      */
     public function testCurrentCallsDataSourceCurrentAsManyTimesWithoutBuffer(): void
@@ -60,5 +46,19 @@ final class AbstractResultSetIntegrationTest extends TestCase
         $value2 = $this->resultSet->current();
         $this->resultSet->current();
         self::assertEquals($value1, $value2);
+    }
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     *
+     * @throws Exception
+     */
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->resultSet = $this->getMockBuilder(AbstractResultSet::class)
+            ->onlyMethods(['toArray'])
+            ->getMock();
     }
 }

--- a/test/unit/ResultSet/AbstractResultSetTest.php
+++ b/test/unit/ResultSet/AbstractResultSetTest.php
@@ -19,7 +19,6 @@ use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 use TypeError;
 
 use function assert;
@@ -35,26 +34,203 @@ use function assert;
 #[CoversMethod(AbstractResultSet::class, 'valid')]
 #[CoversMethod(AbstractResultSet::class, 'rewind')]
 #[CoversMethod(AbstractResultSet::class, 'count')]
-#[CoversMethod(AbstractResultSet::class, 'toArray')]
 final class AbstractResultSetTest extends TestCase
 {
     protected MockObject|AbstractResultSet $resultSet;
 
-    private function createResultSetMock(): MockObject|AbstractResultSet
+    /**
+     * @throws Exception
+     */
+    public function testBuffer(): void
     {
-        return $this->getMockBuilder(AbstractResultSet::class)
-            ->onlyMethods(['setRowPrototype', 'getRowPrototype'])
-            ->getMock();
+        $resultSet = $this->createResultSetMock();
+        // Verify buffer() returns fluent interface
+        self::assertSame($resultSet, $resultSet->buffer());
+
+        $resultSet = $this->createResultSetMock();
+        $resultSet->initialize(new ArrayIterator([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+            ['id' => 3, 'name' => 'three'],
+        ]));
+        $resultSet->next(); // start iterator
+        // Verify buffer() throws exception when called after iteration starts
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Buffering must be enabled before iteration is started');
+        $resultSet->buffer();
     }
 
     /**
-     * Sets up the fixture, for example, opens a network connection.
-     * This method is called before a test is executed.
+     * Test multiple iterations with buffer
+     *
+     * @throws Exception
      */
-    #[Override]
-    protected function setUp(): void
+    #[Group('issue-6845')]
+    public function testBufferIterations(): void
     {
-        $this->resultSet = $this->createResultSetMock();
+        $resultSet = $this->createResultSetMock();
+        $resultSet->initialize(new ArrayIterator([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+            ['id' => 3, 'name' => 'three'],
+        ]));
+        $resultSet->buffer();
+
+        // Iterate through rows and verify data
+        $data = $resultSet->current();
+        self::assertEquals(1, $data['id']);
+        $resultSet->next();
+        $data = $resultSet->current();
+        self::assertEquals(2, $data['id']);
+
+        // Rewind and iterate again to verify buffering allows rewind
+        $resultSet->rewind();
+        $data = $resultSet->current();
+        self::assertEquals(1, $data['id']);
+        $resultSet->next();
+        $data = $resultSet->current();
+        self::assertEquals(2, $data['id']);
+        $resultSet->next();
+        $data = $resultSet->current();
+        self::assertEquals(3, $data['id']);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testCount(): void
+    {
+        $resultSet = $this->createResultSetMock();
+        $resultSet->initialize(new ArrayIterator([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+            ['id' => 3, 'name' => 'three'],
+        ]));
+        // Verify count() returns total number of rows
+        self::assertEquals(3, $resultSet->count());
+    }
+
+    public function testCountReturnsCachedResult(): void
+    {
+        $resultSet = $this->createResultSetMock();
+        $resultSet->initialize([['id' => 1], ['id' => 2]]);
+
+        $first  = $resultSet->count();
+        $second = $resultSet->count();
+
+        self::assertSame(2, $first);
+        self::assertSame($first, $second);
+    }
+
+    public function testCountReturnsNullForUncountableDataSource(): void
+    {
+        $resultSet = $this->createResultSetMock();
+        $iterator  = new NoRewindIterator(new ArrayIterator([['id' => 1]]));
+        $resultSet->initialize($iterator);
+
+        self::assertNull($resultSet->count());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testCurrent(): void
+    {
+        $resultSet = $this->createResultSetMock();
+        $resultSet->initialize(new ArrayIterator([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+            ['id' => 3, 'name' => 'three'],
+        ]));
+        // Verify current() returns the current row
+        self::assertEquals(['id' => 1, 'name' => 'one'], $resultSet->current());
+    }
+
+    public function testCurrentReturnsBufferedDataOnSecondPass(): void
+    {
+        $resultSet = $this->createResultSetMock();
+        $resultSet->initialize(new ArrayIterator([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+        ]));
+        $resultSet->buffer();
+
+        $firstPass = [];
+        foreach ($resultSet as $row) {
+            $firstPass[] = $row;
+        }
+
+        $resultSet->rewind();
+
+        $secondPass = [];
+        foreach ($resultSet as $row) {
+            $secondPass[] = $row;
+        }
+
+        self::assertEquals($firstPass, $secondPass);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetDataSource(): void
+    {
+        $resultSet = $this->createResultSetMock();
+        $resultSet->initialize(new ArrayIterator([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+            ['id' => 3, 'name' => 'three'],
+        ]));
+        // Verify getDataSource() returns the initialized iterator
+        self::assertInstanceOf(ArrayIterator::class, $resultSet->getDataSource());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetFieldCount(): void
+    {
+        $resultSet = $this->createResultSetMock();
+        $resultSet->initialize(new ArrayIterator([
+            ['id' => 1, 'name' => 'one'],
+        ]));
+        // Verify getFieldCount() returns number of columns in current row
+        self::assertEquals(2, $resultSet->getFieldCount());
+    }
+
+    public function testGetFieldCountReturnsCachedValue(): void
+    {
+        $resultSet = $this->createResultSetMock();
+        $resultSet->initialize([['a' => 1, 'b' => 2]]);
+
+        $first  = $resultSet->getFieldCount();
+        $second = $resultSet->getFieldCount();
+
+        self::assertSame(2, $first);
+        self::assertSame($first, $second);
+    }
+
+    public function testGetFieldCountReturnsZeroForEmptyIterator(): void
+    {
+        $resultSet = $this->createResultSetMock();
+        $resultSet->initialize(new ArrayIterator([]));
+
+        self::assertSame(0, $resultSet->getFieldCount());
+    }
+
+    public function testGetFieldCountReturnsZeroWithNoDataSource(): void
+    {
+        $resultSet = $this->createResultSetMock();
+
+        self::assertSame(0, $resultSet->getFieldCount());
+    }
+
+    public function testGetFieldCountWithCountableRow(): void
+    {
+        $resultSet = $this->createResultSetMock();
+        $resultSet->initialize(new ArrayIterator([new ArrayObject(['a' => 1, 'b' => 2, 'c' => 3])]));
+
+        self::assertSame(3, $resultSet->getFieldCount());
     }
 
     /**
@@ -92,6 +268,32 @@ final class AbstractResultSetTest extends TestCase
     /**
      * @throws Exception
      */
+    public function testInitializeResetsBufferWhenAlreadyBuffered(): void
+    {
+        $resultSet = $this->createResultSetMock();
+        $resultSet->initialize(new ArrayIterator([['id' => 1]]));
+        $resultSet->buffer();
+
+        $resultSet->initialize(new ArrayIterator([['id' => 2]]));
+
+        self::assertSame(2, $resultSet->current()['id']);
+    }
+
+    public function testInitializeWithBufferedResultInterface(): void
+    {
+        $result = $this->createMock(ResultInterface::class);
+        $result->method('isBuffered')->willReturn(true);
+        $result->method('getFieldCount')->willReturn(2);
+
+        $resultSet = $this->createResultSetMock();
+        $resultSet->initialize($result);
+
+        self::assertTrue($resultSet->isBuffered());
+    }
+
+    /**
+     * @throws Exception
+     */
     public function testInitializeWithEmptyArray(): void
     {
         $resultSet = $this->createResultSetMock();
@@ -102,23 +304,36 @@ final class AbstractResultSetTest extends TestCase
     /**
      * @throws Exception
      */
-    public function testBuffer(): void
+    public function testInitializeWithIteratorAggregate(): void
     {
         $resultSet = $this->createResultSetMock();
-        // Verify buffer() returns fluent interface
-        self::assertSame($resultSet, $resultSet->buffer());
+        $aggregate = new class implements IteratorAggregate {
+            public function getIterator(): ArrayIterator
+            {
+                return new ArrayIterator([['id' => 1], ['id' => 2]]);
+            }
+        };
 
+        $resultSet->initialize($aggregate);
+
+        self::assertSame(1, $resultSet->current()['id']);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testInitializeWithResultInterfaceRewindsWhenBuffered(): void
+    {
         $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([
-            ['id' => 1, 'name' => 'one'],
-            ['id' => 2, 'name' => 'two'],
-            ['id' => 3, 'name' => 'three'],
-        ]));
-        $resultSet->next(); // start iterator
-        // Verify buffer() throws exception when called after iteration starts
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Buffering must be enabled before iteration is started');
+        $resultSet->initialize(new ArrayIterator([['id' => 1]]));
         $resultSet->buffer();
+
+        $result = $this->createMock(ResultInterface::class);
+        $result->method('getFieldCount')->willReturn(2);
+        $result->method('isBuffered')->willReturn(false);
+        $result->expects(self::once())->method('rewind');
+
+        $resultSet->initialize($result);
     }
 
     public function testIsBuffered(): void
@@ -129,54 +344,6 @@ final class AbstractResultSetTest extends TestCase
         $resultSet->buffer();
         // Verify buffering is enabled after buffer() call
         self::assertTrue($resultSet->isBuffered());
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function testGetDataSource(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([
-            ['id' => 1, 'name' => 'one'],
-            ['id' => 2, 'name' => 'two'],
-            ['id' => 3, 'name' => 'three'],
-        ]));
-        // Verify getDataSource() returns the initialized iterator
-        self::assertInstanceOf(ArrayIterator::class, $resultSet->getDataSource());
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function testGetFieldCount(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([
-            ['id' => 1, 'name' => 'one'],
-        ]));
-        // Verify getFieldCount() returns number of columns in current row
-        self::assertEquals(2, $resultSet->getFieldCount());
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function testNext(): void
-    {
-        $rows = [
-            ['id' => 1, 'name' => 'one'],
-            ['id' => 2, 'name' => 'two'],
-            ['id' => 3, 'name' => 'three'],
-        ];
-
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator($rows));
-
-        // Verify next() advances iterator position
-        self::assertSame(0, $resultSet->key());
-        $resultSet->next();
-        self::assertSame(1, $resultSet->key());
     }
 
     /**
@@ -197,213 +364,6 @@ final class AbstractResultSetTest extends TestCase
         self::assertEquals(2, $resultSet->key());
         $resultSet->next();
         self::assertEquals(3, $resultSet->key());
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function testCurrent(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([
-            ['id' => 1, 'name' => 'one'],
-            ['id' => 2, 'name' => 'two'],
-            ['id' => 3, 'name' => 'three'],
-        ]));
-        // Verify current() returns the current row
-        self::assertEquals(['id' => 1, 'name' => 'one'], $resultSet->current());
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function testValid(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([
-            ['id' => 1, 'name' => 'one'],
-            ['id' => 2, 'name' => 'two'],
-            ['id' => 3, 'name' => 'three'],
-        ]));
-        // Verify valid() returns true when iterator is at valid position
-        self::assertTrue($resultSet->valid());
-        $resultSet->next();
-        $resultSet->next();
-        $resultSet->next();
-        // Verify valid() returns false after iterating past last element
-        self::assertFalse($resultSet->valid());
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function testRewindResetsIteratorPosition(): void
-    {
-            $rows = [
-                ['id' => 1, 'name' => 'one'],
-                ['id' => 2, 'name' => 'two'],
-                ['id' => 3, 'name' => 'three'],
-            ];
-
-            $this->resultSet->initialize(new ArrayIterator($rows));
-
-            // Move forward to ensure position changes
-            $this->resultSet->next();
-            self::assertSame(1, $this->resultSet->key());
-
-            // Verify rewind() resets iterator position and current row
-            $this->resultSet->rewind();
-            self::assertSame(0, $this->resultSet->key());
-            self::assertEquals($rows[0], $this->resultSet->current());
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function testCount(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([
-            ['id' => 1, 'name' => 'one'],
-            ['id' => 2, 'name' => 'two'],
-            ['id' => 3, 'name' => 'three'],
-        ]));
-        // Verify count() returns total number of rows
-        self::assertEquals(3, $resultSet->count());
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function testToArray(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([
-            ['id' => 1, 'name' => 'one'],
-            ['id' => 2, 'name' => 'two'],
-            ['id' => 3, 'name' => 'three'],
-        ]));
-        // Verify toArray() returns all rows as array
-        self::assertEquals(
-            [
-                ['id' => 1, 'name' => 'one'],
-                ['id' => 2, 'name' => 'two'],
-                ['id' => 3, 'name' => 'three'],
-            ],
-            $resultSet->toArray()
-        );
-    }
-
-    public function testCurrentReturnsBufferedDataOnSecondPass(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([
-            ['id' => 1, 'name' => 'one'],
-            ['id' => 2, 'name' => 'two'],
-        ]));
-        $resultSet->buffer();
-
-        $firstPass = [];
-        foreach ($resultSet as $row) {
-            $firstPass[] = $row;
-        }
-
-        $resultSet->rewind();
-
-        $secondPass = [];
-        foreach ($resultSet as $row) {
-            $secondPass[] = $row;
-        }
-
-        self::assertEquals($firstPass, $secondPass);
-    }
-
-    public function testToArrayConvertsArrayObjectsViaGetArrayCopy(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize([
-            new ArrayObject(['id' => 1, 'name' => 'one']),
-        ]);
-
-        $result = $resultSet->toArray();
-
-        self::assertSame([['id' => 1, 'name' => 'one']], $result);
-    }
-
-    public function testGetFieldCountReturnsZeroForEmptyIterator(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([]));
-
-        self::assertSame(0, $resultSet->getFieldCount());
-    }
-
-    public function testInitializeWithBufferedResultInterface(): void
-    {
-        $result = $this->createMock(ResultInterface::class);
-        $result->method('isBuffered')->willReturn(true);
-        $result->method('getFieldCount')->willReturn(2);
-
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize($result);
-
-        self::assertTrue($resultSet->isBuffered());
-    }
-
-    public function testCountReturnsNullForUncountableDataSource(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $iterator  = new NoRewindIterator(new ArrayIterator([['id' => 1]]));
-        $resultSet->initialize($iterator);
-
-        self::assertNull($resultSet->count());
-    }
-
-    public function testValidReturnsFalseAfterLastElement(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([
-            ['id' => 1],
-        ]));
-
-        self::assertTrue($resultSet->valid());
-        $resultSet->next();
-        self::assertFalse($resultSet->valid());
-    }
-
-    /**
-     * Test multiple iterations with buffer
-     *
-     * @throws Exception
-     */
-    #[Group('issue-6845')]
-    public function testBufferIterations(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([
-            ['id' => 1, 'name' => 'one'],
-            ['id' => 2, 'name' => 'two'],
-            ['id' => 3, 'name' => 'three'],
-        ]));
-        $resultSet->buffer();
-
-        // Iterate through rows and verify data
-        $data = $resultSet->current();
-        self::assertEquals(1, $data['id']);
-        $resultSet->next();
-        $data = $resultSet->current();
-        self::assertEquals(2, $data['id']);
-
-        // Rewind and iterate again to verify buffering allows rewind
-        $resultSet->rewind();
-        $data = $resultSet->current();
-        self::assertEquals(1, $data['id']);
-        $resultSet->next();
-        $data = $resultSet->current();
-        self::assertEquals(2, $data['id']);
-        $resultSet->next();
-        $data = $resultSet->current();
-        self::assertEquals(3, $data['id']);
     }
 
     /**
@@ -463,93 +423,44 @@ final class AbstractResultSetTest extends TestCase
     /**
      * @throws Exception
      */
-    public function testInitializeResetsBufferWhenAlreadyBuffered(): void
+    public function testNext(): void
     {
+        $rows = [
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+            ['id' => 3, 'name' => 'three'],
+        ];
+
         $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([['id' => 1]]));
-        $resultSet->buffer();
+        $resultSet->initialize(new ArrayIterator($rows));
 
-        $resultSet->initialize(new ArrayIterator([['id' => 2]]));
-
-        self::assertSame(2, $resultSet->current()['id']);
+        // Verify next() advances iterator position
+        self::assertSame(0, $resultSet->key());
+        $resultSet->next();
+        self::assertSame(1, $resultSet->key());
     }
 
     /**
      * @throws Exception
      */
-    public function testInitializeWithResultInterfaceRewindsWhenBuffered(): void
+    public function testRewindResetsIteratorPosition(): void
     {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([['id' => 1]]));
-        $resultSet->buffer();
+        $rows = [
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+            ['id' => 3, 'name' => 'three'],
+        ];
 
-        $result = $this->createMock(ResultInterface::class);
-        $result->method('getFieldCount')->willReturn(2);
-        $result->method('isBuffered')->willReturn(false);
-        $result->expects(self::once())->method('rewind');
+        $this->resultSet->initialize(new ArrayIterator($rows));
 
-        $resultSet->initialize($result);
-    }
+        // Move forward to ensure position changes
+        $this->resultSet->next();
+        self::assertSame(1, $this->resultSet->key());
 
-    /**
-     * @throws Exception
-     */
-    public function testInitializeWithIteratorAggregate(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $aggregate = new class implements IteratorAggregate {
-            public function getIterator(): ArrayIterator
-            {
-                return new ArrayIterator([['id' => 1], ['id' => 2]]);
-            }
-        };
-
-        $resultSet->initialize($aggregate);
-
-        self::assertSame(1, $resultSet->current()['id']);
-    }
-
-    public function testGetFieldCountReturnsCachedValue(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize([['a' => 1, 'b' => 2]]);
-
-        $first  = $resultSet->getFieldCount();
-        $second = $resultSet->getFieldCount();
-
-        self::assertSame(2, $first);
-        self::assertSame($first, $second);
-    }
-
-    public function testGetFieldCountReturnsZeroWithNoDataSource(): void
-    {
-        $resultSet = $this->createResultSetMock();
-
-        self::assertSame(0, $resultSet->getFieldCount());
-    }
-
-    public function testGetFieldCountWithCountableRow(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([new ArrayObject(['a' => 1, 'b' => 2, 'c' => 3])]));
-
-        self::assertSame(3, $resultSet->getFieldCount());
-    }
-
-    public function testValidWithNonIteratorDataSource(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $aggregate = new class implements IteratorAggregate {
-            public function getIterator(): ArrayIterator
-            {
-                return new ArrayIterator([['id' => 1]]);
-            }
-        };
-
-        $resultSet->initialize($aggregate);
-        $resultSet->rewind();
-
-        self::assertTrue($resultSet->valid());
+        // Verify rewind() resets iterator position and current row
+        $this->resultSet->rewind();
+        self::assertSame(0, $this->resultSet->key());
+        self::assertEquals($rows[0], $this->resultSet->current());
     }
 
     public function testRewindWithNonIteratorDataSource(): void
@@ -569,25 +480,68 @@ final class AbstractResultSetTest extends TestCase
         self::assertSame(0, $resultSet->key());
     }
 
-    public function testCountReturnsCachedResult(): void
+    /**
+     * @throws Exception
+     */
+    public function testValid(): void
     {
         $resultSet = $this->createResultSetMock();
-        $resultSet->initialize([['id' => 1], ['id' => 2]]);
-
-        $first  = $resultSet->count();
-        $second = $resultSet->count();
-
-        self::assertSame(2, $first);
-        self::assertSame($first, $second);
+        $resultSet->initialize(new ArrayIterator([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+            ['id' => 3, 'name' => 'three'],
+        ]));
+        // Verify valid() returns true when iterator is at valid position
+        self::assertTrue($resultSet->valid());
+        $resultSet->next();
+        $resultSet->next();
+        $resultSet->next();
+        // Verify valid() returns false after iterating past last element
+        self::assertFalse($resultSet->valid());
     }
 
-    public function testToArrayThrowsOnNonCastableRows(): void
+    public function testValidReturnsFalseAfterLastElement(): void
     {
         $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([new stdClass()]));
+        $resultSet->initialize(new ArrayIterator([
+            ['id' => 1],
+        ]));
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('cannot be cast to an array');
-        $resultSet->toArray();
+        self::assertTrue($resultSet->valid());
+        $resultSet->next();
+        self::assertFalse($resultSet->valid());
+    }
+
+    public function testValidWithNonIteratorDataSource(): void
+    {
+        $resultSet = $this->createResultSetMock();
+        $aggregate = new class implements IteratorAggregate {
+            public function getIterator(): ArrayIterator
+            {
+                return new ArrayIterator([['id' => 1]]);
+            }
+        };
+
+        $resultSet->initialize($aggregate);
+        $resultSet->rewind();
+
+        self::assertTrue($resultSet->valid());
+    }
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->resultSet = $this->createResultSetMock();
+    }
+
+    private function createResultSetMock(): MockObject|AbstractResultSet
+    {
+        return $this->getMockBuilder(AbstractResultSet::class)
+            ->onlyMethods(['toArray'])
+            ->getMock();
     }
 }

--- a/test/unit/ResultSet/ResultSetIntegrationTest.php
+++ b/test/unit/ResultSet/ResultSetIntegrationTest.php
@@ -37,56 +37,6 @@ final class ResultSetIntegrationTest extends TestCase
 {
     protected ResultSet $resultSet;
 
-    /**
-     * Sets up the fixture, for example, opens a network connection.
-     * This method is called before a test is executed.
-     */
-    #[Override]
-    protected function setUp(): void
-    {
-        $this->resultSet = new ResultSet();
-    }
-
-    public function testRowObjectPrototypeIsPopulatedByRowObjectByDefault(): void
-    {
-        // Verify default row object prototype is ArrayObject
-        $row = $this->resultSet->getArrayObjectPrototype();
-        self::assertInstanceOf('ArrayObject', $row);
-    }
-
-    public function testRowObjectPrototypeIsMutable(): void
-    {
-        $row1 = new ArrayObject(['test1' => 'value1']);
-        $row2 = new ArrayObject(['test2' => 'value2']);
-
-        // First mutation
-        $this->resultSet->setArrayObjectPrototype($row1);
-
-        // Verify the first mutation occurred
-        self::assertSame($row1, $this->resultSet->getArrayObjectPrototype());
-
-        // Second mutation to verify mutability
-        $this->resultSet->setArrayObjectPrototype($row2);
-
-        // Verify the instance was actually mutated
-        self::assertSame($row2, $this->resultSet->getArrayObjectPrototype());
-        self::assertNotSame($row1, $this->resultSet->getArrayObjectPrototype());
-    }
-
-    public function testRowObjectPrototypeMayBePassedToConstructor(): void
-    {
-        $row = new ArrayObject();
-        // Verify prototype can be passed to constructor
-        $resultSet = new ResultSet(ResultSet::TYPE_ARRAYOBJECT, $row);
-        self::assertSame($row, $resultSet->getArrayObjectPrototype());
-    }
-
-    public function testReturnTypeIsObjectByDefault(): void
-    {
-        // Verify default return type is ArrayObject
-        self::assertEquals(ResultSetReturnType::ArrayObject, $this->resultSet->getReturnType());
-    }
-
     /** @psalm-return array<array-key, array{0: mixed}> */
     public static function invalidReturnTypes(): array
     {
@@ -100,29 +50,32 @@ final class ResultSetIntegrationTest extends TestCase
         ];
     }
 
-    #[DataProvider('invalidReturnTypes')]
-    public function testSettingInvalidReturnTypeRaisesException(mixed $type): void
+    public function getArrayDataSource(int $count): ArrayIterator
     {
-        // Verify invalid return type throws TypeError
-        $this->expectException(TypeError::class);
-        new ResultSet(ResultSet::TYPE_ARRAYOBJECT, $type);
-    }
+        $array = [];
+        for ($i = 0; $i < $count; $i++) {
+            $array[] = [
+                'id'    => $i,
+                'title' => 'title ' . $i,
+            ];
+        }
 
-    public function testDataSourceIsNullByDefault(): void
-    {
-        // Verify data source is null before initialization
-        self::assertNull($this->resultSet->getDataSource());
+        return new ArrayIterator($array);
     }
 
     /**
+     * @throws Exception
      * @throws \Exception
      */
-    public function testCanProvideIteratorAsDataSource(): void
+    public function testBufferCalledAfterIterationThrowsException(): void
     {
-        $it = new SplStack();
-        // Initialize with iterator and verify it is stored as data source
-        $this->resultSet->initialize($it);
-        self::assertSame($it, $this->resultSet->getDataSource());
+        $this->resultSet->initialize($this->createMock(ResultInterface::class));
+        $this->resultSet->current();
+
+        // Verify buffer() throws exception when called after iteration has started
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Buffering must be enabled before iteration is started');
+        $this->resultSet->buffer();
     }
 
     /**
@@ -161,6 +114,139 @@ final class ResultSetIntegrationTest extends TestCase
     /**
      * @throws \Exception
      */
+    public function testCanProvideIteratorAsDataSource(): void
+    {
+        $it = new SplStack();
+        // Initialize with iterator and verify it is stored as data source
+        $this->resultSet->initialize($it);
+        self::assertSame($it, $this->resultSet->getDataSource());
+    }
+
+    /**
+     * @throws RandomException
+     * @throws \Exception
+     */
+    public function testCountReturnsCountOfRows(): void
+    {
+        $count      = random_int(3, 75);
+        $dataSource = $this->getArrayDataSource($count);
+        // Verify count() returns correct number of rows
+        $this->resultSet->initialize($dataSource);
+        self::assertEquals($count, $this->resultSet->count());
+    }
+
+    public function testCurrentClonesRowPrototypeOnEachCall(): void
+    {
+        $resultSet = new ResultSet(ResultSetReturnType::ArrayObject);
+        $resultSet->initialize([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+        ]);
+
+        $first = $resultSet->current();
+        $resultSet->next();
+        $second = $resultSet->current();
+
+        self::assertNotSame($first, $second);
+    }
+
+    public function testCurrentReturnsArrayObjectWhenReturnTypeIsArrayObject(): void
+    {
+        $resultSet = new ResultSet(ResultSetReturnType::ArrayObject);
+        $resultSet->initialize([['id' => 1, 'name' => 'one']]);
+
+        $current = $resultSet->current();
+
+        self::assertInstanceOf(ArrayObject::class, $current);
+        self::assertSame(1, $current['id']);
+    }
+
+    public function testCurrentReturnsArrayWhenReturnTypeIsArray(): void
+    {
+        $resultSet = new ResultSet(ResultSetReturnType::Array);
+        $resultSet->initialize([['id' => 1, 'name' => 'one']]);
+
+        $current = $resultSet->current();
+
+        self::assertIsArray($current);
+        self::assertSame(1, $current['id']);
+    }
+
+    /**
+     * @throws Exception
+     * @throws \Exception
+     */
+    public function testCurrentReturnsNullForNonExistingValues(): void
+    {
+        $mockResult = $this->createMock(ResultInterface::class);
+        $mockResult->expects($this->once())->method('current')->willReturn('Not an Array');
+
+        $this->resultSet->initialize($mockResult);
+        $this->resultSet->buffer();
+
+        // Verify current() returns null when data source returns non-array value
+        self::assertNull($this->resultSet->current());
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testCurrentWithBufferingCallsDataSourceCurrentOnce(): void
+    {
+        $mockResult = $this->getMockBuilder(ResultInterface::class)->getMock();
+        $mockResult->expects($this->once())->method('current')->willReturn(['foo' => 'bar']);
+
+        $this->resultSet->initialize($mockResult);
+        $this->resultSet->buffer();
+        // Call current() twice and verify data source is only called once due to buffering
+        $this->resultSet->current();
+
+        // assertion above will fail if this calls datasource current
+        $this->resultSet->current();
+    }
+
+    public function testDataSourceIsNullByDefault(): void
+    {
+        // Verify data source is null before initialization
+        self::assertNull($this->resultSet->getDataSource());
+    }
+
+    public function testFieldCountIsZeroWithNoDataSourcePresent(): void
+    {
+        // Verify field count is 0 when no data source is set
+        self::assertEquals(0, $this->resultSet->getFieldCount());
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testFieldCountRepresentsNumberOfFieldsInARowOfData(): void
+    {
+        $resultSet  = new ResultSet(ResultSet::TYPE_ARRAY);
+        $dataSource = $this->getArrayDataSource(10);
+        // Verify field count matches number of columns in row data
+        $resultSet->initialize($dataSource);
+        self::assertEquals(2, $resultSet->getFieldCount());
+    }
+
+    public function testGetArrayObjectPrototypeDelegatesToGetRowPrototype(): void
+    {
+        self::assertSame(
+            $this->resultSet->getRowPrototype(),
+            $this->resultSet->getArrayObjectPrototype(),
+        );
+    }
+
+    public function testGetReturnTypeReturnsArrayWhenSetToArray(): void
+    {
+        $resultSet = new ResultSet(ResultSetReturnType::Array);
+
+        self::assertSame(ResultSetReturnType::Array, $resultSet->getReturnType());
+    }
+
+    /**
+     * @throws \Exception
+     */
     #[DataProvider('invalidReturnTypes')]
     public function testInvalidDataSourceRaisesException(mixed $dataSource): void
     {
@@ -175,35 +261,66 @@ final class ResultSetIntegrationTest extends TestCase
         $this->resultSet->initialize($dataSource);
     }
 
-    public function testFieldCountIsZeroWithNoDataSourcePresent(): void
+    public function testReturnTypeIsObjectByDefault(): void
     {
-        // Verify field count is 0 when no data source is set
-        self::assertEquals(0, $this->resultSet->getFieldCount());
+        // Verify default return type is ArrayObject
+        self::assertEquals(ResultSetReturnType::ArrayObject, $this->resultSet->getReturnType());
     }
 
-    public function getArrayDataSource(int $count): ArrayIterator
+    public function testRowObjectPrototypeIsMutable(): void
     {
-        $array = [];
-        for ($i = 0; $i < $count; $i++) {
-            $array[] = [
-                'id'    => $i,
-                'title' => 'title ' . $i,
-            ];
-        }
+        $row1 = new ArrayObject(['test1' => 'value1']);
+        $row2 = new ArrayObject(['test2' => 'value2']);
 
-        return new ArrayIterator($array);
+        // First mutation
+        $this->resultSet->setArrayObjectPrototype($row1);
+
+        // Verify the first mutation occurred
+        self::assertSame($row1, $this->resultSet->getArrayObjectPrototype());
+
+        // Second mutation to verify mutability
+        $this->resultSet->setArrayObjectPrototype($row2);
+
+        // Verify the instance was actually mutated
+        self::assertSame($row2, $this->resultSet->getArrayObjectPrototype());
+        self::assertNotSame($row1, $this->resultSet->getArrayObjectPrototype());
+    }
+
+    public function testRowObjectPrototypeIsPopulatedByRowObjectByDefault(): void
+    {
+        // Verify default row object prototype is ArrayObject
+        $row = $this->resultSet->getArrayObjectPrototype();
+        self::assertInstanceOf('ArrayObject', $row);
+    }
+
+    public function testRowObjectPrototypeMayBePassedToConstructor(): void
+    {
+        $row = new ArrayObject();
+        // Verify prototype can be passed to constructor
+        $resultSet = new ResultSet(ResultSet::TYPE_ARRAYOBJECT, $row);
+        self::assertSame($row, $resultSet->getArrayObjectPrototype());
+    }
+
+    #[DataProvider('invalidReturnTypes')]
+    public function testSettingInvalidReturnTypeRaisesException(mixed $type): void
+    {
+        // Verify invalid return type throws TypeError
+        $this->expectException(TypeError::class);
+        new ResultSet(ResultSet::TYPE_ARRAYOBJECT, $type);
     }
 
     /**
+     * @throws RandomException
      * @throws \Exception
      */
-    public function testFieldCountRepresentsNumberOfFieldsInARowOfData(): void
+    public function testToArrayCreatesArrayOfArraysRepresentingRows(): void
     {
-        $resultSet  = new ResultSet(ResultSet::TYPE_ARRAY);
-        $dataSource = $this->getArrayDataSource(10);
-        // Verify field count matches number of columns in row data
-        $resultSet->initialize($dataSource);
-        self::assertEquals(2, $resultSet->getFieldCount());
+        $count      = random_int(3, 75);
+        $dataSource = $this->getArrayDataSource($count);
+        // Verify toArray() returns array representation of all rows
+        $this->resultSet->initialize($dataSource);
+        $test = $this->resultSet->toArray();
+        self::assertEquals($dataSource->getArrayCopy(), $test, var_export($test, true));
     }
 
     /**
@@ -235,147 +352,12 @@ final class ResultSetIntegrationTest extends TestCase
     }
 
     /**
-     * @throws RandomException
-     * @throws \Exception
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
      */
-    public function testCountReturnsCountOfRows(): void
+    #[Override]
+    protected function setUp(): void
     {
-        $count      = random_int(3, 75);
-        $dataSource = $this->getArrayDataSource($count);
-        // Verify count() returns correct number of rows
-        $this->resultSet->initialize($dataSource);
-        self::assertEquals($count, $this->resultSet->count());
-    }
-
-    /**
-     * @throws RandomException
-     * @throws \Exception
-     */
-    public function testToArrayRaisesExceptionForRowsThatAreNotArraysOrArrayCastable(): void
-    {
-        $count      = random_int(3, 75);
-        $dataSource = $this->getArrayDataSource($count);
-        foreach ($dataSource as $index => $row) {
-            $dataSource[$index] = (object) $row;
-        }
-
-        // Verify toArray() throws exception for non-array-castable objects
-        $this->resultSet->initialize($dataSource);
-        $this->expectException(RuntimeException::class);
-        $this->resultSet->toArray();
-    }
-
-    /**
-     * @throws RandomException
-     * @throws \Exception
-     */
-    public function testToArrayCreatesArrayOfArraysRepresentingRows(): void
-    {
-        $count      = random_int(3, 75);
-        $dataSource = $this->getArrayDataSource($count);
-        // Verify toArray() returns array representation of all rows
-        $this->resultSet->initialize($dataSource);
-        $test = $this->resultSet->toArray();
-        self::assertEquals($dataSource->getArrayCopy(), $test, var_export($test, true));
-    }
-
-    /**
-     * @throws \Exception
-     */
-    public function testCurrentWithBufferingCallsDataSourceCurrentOnce(): void
-    {
-        $mockResult = $this->getMockBuilder(ResultInterface::class)->getMock();
-        $mockResult->expects($this->once())->method('current')->willReturn(['foo' => 'bar']);
-
-        $this->resultSet->initialize($mockResult);
-        $this->resultSet->buffer();
-        // Call current() twice and verify data source is only called once due to buffering
-        $this->resultSet->current();
-
-        // assertion above will fail if this calls datasource current
-        $this->resultSet->current();
-    }
-
-    /**
-     * @throws Exception
-     * @throws \Exception
-     */
-    public function testBufferCalledAfterIterationThrowsException(): void
-    {
-        $this->resultSet->initialize($this->createMock(ResultInterface::class));
-        $this->resultSet->current();
-
-        // Verify buffer() throws exception when called after iteration has started
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Buffering must be enabled before iteration is started');
-        $this->resultSet->buffer();
-    }
-
-    /**
-     * @throws Exception
-     * @throws \Exception
-     */
-    public function testCurrentReturnsNullForNonExistingValues(): void
-    {
-        $mockResult = $this->createMock(ResultInterface::class);
-        $mockResult->expects($this->once())->method('current')->willReturn("Not an Array");
-
-        $this->resultSet->initialize($mockResult);
-        $this->resultSet->buffer();
-
-        // Verify current() returns null when data source returns non-array value
-        self::assertNull($this->resultSet->current());
-    }
-
-    public function testCurrentReturnsArrayObjectWhenReturnTypeIsArrayObject(): void
-    {
-        $resultSet = new ResultSet(ResultSetReturnType::ArrayObject);
-        $resultSet->initialize([['id' => 1, 'name' => 'one']]);
-
-        $current = $resultSet->current();
-
-        self::assertInstanceOf(ArrayObject::class, $current);
-        self::assertSame(1, $current['id']);
-    }
-
-    public function testCurrentReturnsArrayWhenReturnTypeIsArray(): void
-    {
-        $resultSet = new ResultSet(ResultSetReturnType::Array);
-        $resultSet->initialize([['id' => 1, 'name' => 'one']]);
-
-        $current = $resultSet->current();
-
-        self::assertIsArray($current);
-        self::assertSame(1, $current['id']);
-    }
-
-    public function testCurrentClonesRowPrototypeOnEachCall(): void
-    {
-        $resultSet = new ResultSet(ResultSetReturnType::ArrayObject);
-        $resultSet->initialize([
-            ['id' => 1, 'name' => 'one'],
-            ['id' => 2, 'name' => 'two'],
-        ]);
-
-        $first = $resultSet->current();
-        $resultSet->next();
-        $second = $resultSet->current();
-
-        self::assertNotSame($first, $second);
-    }
-
-    public function testGetReturnTypeReturnsArrayWhenSetToArray(): void
-    {
-        $resultSet = new ResultSet(ResultSetReturnType::Array);
-
-        self::assertSame(ResultSetReturnType::Array, $resultSet->getReturnType());
-    }
-
-    public function testGetArrayObjectPrototypeDelegatesToGetRowPrototype(): void
-    {
-        self::assertSame(
-            $this->resultSet->getRowPrototype(),
-            $this->resultSet->getArrayObjectPrototype()
-        );
+        $this->resultSet = new ResultSet();
     }
 }


### PR DESCRIPTION
- Trim ResultSetInterface down to Iterator/Countable/initialize/getFieldCount/toArray
- Add standalone ArrayObjectResultSetInterface and HydratingResultSetInterface
  capability interfaces (combined via implements + intersection types, not
  inheritance), so setRowPrototype()/getRowPrototype() no longer force a wide
  ArrayObject|RowPrototypeInterface union onto every implementation
- ResultSet narrows to ArrayObject-only; HydratingResultSet keeps its
  intentionally wide object typing, now isolated to its own interface
- Move toArray() out of AbstractResultSet; each concrete class implements only
  the row-casting logic it actually needs

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>