### PR TITLE
Add ArrayResultSet

### DIFF
--- a/src/ResultSet/ArrayResultSet.php
+++ b/src/ResultSet/ArrayResultSet.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDb\ResultSet;
+
+use Override;
+
+class ArrayResultSet extends AbstractResultSet
+{
+    /** {@inheritDoc} */
+    #[Override]
+    public function toArray(): array
+    {
+        $return = [];
+        foreach ($this as $row) {
+            $return[] = $row;
+        }
+
+        return $return;
+    }
+}


### PR DESCRIPTION
Dedicated ResultSet implementation for plain-array rows, decoupled from
ArrayObjectResultSetInterface's row-prototype capability entirely.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>