### PR TITLE
Add RowPrototypeResultSet; migrate RowGateway to populate()

### DIFF
--- a/analyzer-baseline.toml
+++ b/analyzer-baseline.toml
@@ -1526,12 +1526,6 @@ count = 1
 
 [[issues]]
 file = "src/ResultSet/AbstractResultSet.php"
-code = "ambiguous-object-method-access"
-message = "Cannot statically verify method call on a generic `object` type."
-count = 3
-
-[[issues]]
-file = "src/ResultSet/AbstractResultSet.php"
 code = "imprecise-type"
 message = "Type `array` in property `$buffer` is imprecise, equivalent to `array<array-key, mixed>`."
 count = 1
@@ -1564,12 +1558,6 @@ count = 1
 file = "src/ResultSet/AbstractResultSet.php"
 code = "invalid-type-cast"
 message = "Casting `mixed` to `array`."
-count = 1
-
-[[issues]]
-file = "src/ResultSet/AbstractResultSet.php"
-code = "less-specific-nested-return-statement"
-message = '''Returned type `array{}|non-empty-list<mixed>` is less specific than the declared return type `array<array-key, ArrayObject<array-key, mixed>|PhpDb\ResultSet\RowPrototypeInterface|array<array-key, mixed>>` for function `PhpDb\ResultSet\AbstractResultSet::toArray` due to nested 'mixed'.'''
 count = 1
 
 [[issues]]
@@ -1657,6 +1645,24 @@ message = 'A value of a less specific type `Traversable<mixed, mixed>` is being 
 count = 1
 
 [[issues]]
+file = "src/ResultSet/ArrayObjectResultSetInterface.php"
+code = "missing-api-or-internal"
+message = 'Interface `PhpDb\ResultSet\ArrayObjectResultSetInterface` is missing an `@api` or `@internal` annotation.'
+count = 1
+
+[[issues]]
+file = "src/ResultSet/ArrayResultSet.php"
+code = "class-must-be-final"
+message = 'Class `PhpDb\ResultSet\ArrayResultSet` should be declared `final`.'
+count = 1
+
+[[issues]]
+file = "src/ResultSet/ArrayResultSet.php"
+code = "imprecise-type"
+message = "Type `array` in return type of `toArray` is imprecise, equivalent to `array<array-key, mixed>`."
+count = 1
+
+[[issues]]
 file = "src/ResultSet/Exception/ExceptionInterface.php"
 code = "missing-api-or-internal"
 message = 'Interface `PhpDb\ResultSet\Exception\ExceptionInterface` is missing an `@api` or `@internal` annotation.'
@@ -1682,8 +1688,8 @@ count = 1
 
 [[issues]]
 file = "src/ResultSet/HydratingResultSet.php"
-code = "less-specific-argument"
-message = 'Argument type mismatch for argument #1 of `PhpDb\ResultSet\HydratingResultSet::setRowPrototype`: expected `ArrayObject<array-key, mixed>|PhpDb\ResultSet\RowPrototypeInterface`, but provided type `object` is less specific.'
+code = "imprecise-type"
+message = "Type `array` in return type of `toArray` is imprecise, equivalent to `array<array-key, mixed>`."
 count = 1
 
 [[issues]]
@@ -1723,6 +1729,12 @@ message = 'Argument #1 of method `Laminas\Hydrator\ExtractionInterface::extract`
 count = 1
 
 [[issues]]
+file = "src/ResultSet/HydratingResultSetInterface.php"
+code = "missing-api-or-internal"
+message = 'Interface `PhpDb\ResultSet\HydratingResultSetInterface` is missing an `@api` or `@internal` annotation.'
+count = 1
+
+[[issues]]
 file = "src/ResultSet/ResultSet.php"
 code = "class-must-be-final"
 message = 'Class `PhpDb\ResultSet\ResultSet` should be declared `final`.'
@@ -1736,20 +1748,20 @@ count = 1
 
 [[issues]]
 file = "src/ResultSet/ResultSet.php"
+code = "imprecise-type"
+message = "Type `array` in return type of `toArray` is imprecise, equivalent to `array<array-key, mixed>`."
+count = 1
+
+[[issues]]
+file = "src/ResultSet/ResultSet.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `PhpDb\ResultSet\ResultSet::getReturnType`: expected `enum(PhpDb\ResultSet\ResultSetReturnType)`, but found `enum(PhpDb\ResultSet\ResultSetReturnType)|string`.'
 count = 1
 
 [[issues]]
 file = "src/ResultSet/ResultSet.php"
-code = "invalid-return-statement"
-message = 'Invalid return type for function `PhpDb\ResultSet\ResultSet::getRowPrototype`: expected `ArrayObject<array-key, mixed>|PhpDb\ResultSet\RowPrototypeInterface`, but found `ArrayObject<array-key, mixed>|PhpDb\ResultSet\RowPrototypeInterface|null`.'
-count = 1
-
-[[issues]]
-file = "src/ResultSet/ResultSet.php"
 code = "less-specific-return-statement"
-message = 'Returned type `array<array-key, mixed>|null|object` is less specific than the declared return type `ArrayObject<array-key, mixed>|PhpDb\ResultSet\RowPrototypeInterface|array<array-key, mixed>|null` for function `PhpDb\ResultSet\ResultSet::current`.'
+message = 'Returned type `array<array-key, mixed>|null|object` is less specific than the declared return type `ArrayObject<array-key, mixed>|array<array-key, mixed>|null` for function `PhpDb\ResultSet\ResultSet::current`.'
 count = 1
 
 [[issues]]
@@ -1765,9 +1777,9 @@ message = "Class constant `TYPE_ARRAY` is missing a type hint."
 count = 1
 
 [[issues]]
-file = "src/ResultSet/ResultSet.php"
-code = "nullable-return-statement"
-message = 'Function `PhpDb\ResultSet\ResultSet::getRowPrototype` is declared to return `ArrayObject<array-key, mixed>|PhpDb\ResultSet\RowPrototypeInterface` but possibly returns a nullable value (inferred as `ArrayObject<array-key, mixed>|PhpDb\ResultSet\RowPrototypeInterface|null`).'
+file = "src/ResultSet/ResultSetInterface.php"
+code = "imprecise-type"
+message = "Type `array` in return type of `toArray` is imprecise, equivalent to `array<array-key, mixed>`."
 count = 1
 
 [[issues]]
@@ -1791,13 +1803,7 @@ count = 1
 [[issues]]
 file = "src/ResultSet/RowPrototypeInterface.php"
 code = "imprecise-type"
-message = "Type `array` in parameter `$array` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "src/ResultSet/RowPrototypeInterface.php"
-code = "imprecise-type"
-message = "Type `array` in return type of `exchangeArray` is imprecise, equivalent to `array<array-key, mixed>`."
+message = "Type `array` in parameter `$data` is imprecise, equivalent to `array<array-key, mixed>`."
 count = 1
 
 [[issues]]
@@ -1810,6 +1816,36 @@ count = 1
 file = "src/ResultSet/RowPrototypeInterface.php"
 code = "missing-api-or-internal"
 message = 'Interface `PhpDb\ResultSet\RowPrototypeInterface` is missing an `@api` or `@internal` annotation.'
+count = 1
+
+[[issues]]
+file = "src/ResultSet/RowPrototypeResultSet.php"
+code = "class-must-be-final"
+message = 'Class `PhpDb\ResultSet\RowPrototypeResultSet` should be declared `final`.'
+count = 1
+
+[[issues]]
+file = "src/ResultSet/RowPrototypeResultSet.php"
+code = "imprecise-type"
+message = "Type `array` in return type of `current` is imprecise, equivalent to `array<array-key, mixed>`."
+count = 1
+
+[[issues]]
+file = "src/ResultSet/RowPrototypeResultSet.php"
+code = "imprecise-type"
+message = "Type `array` in return type of `toArray` is imprecise, equivalent to `array<array-key, mixed>`."
+count = 1
+
+[[issues]]
+file = "src/ResultSet/RowPrototypeResultSet.php"
+code = "less-specific-return-statement"
+message = 'Returned type `null|object` is less specific than the declared return type `PhpDb\ResultSet\RowPrototypeInterface|array<array-key, mixed>|null` for function `PhpDb\ResultSet\RowPrototypeResultSet::current`.'
+count = 1
+
+[[issues]]
+file = "src/ResultSet/RowPrototypeResultSetInterface.php"
+code = "missing-api-or-internal"
+message = 'Interface `PhpDb\ResultSet\RowPrototypeResultSetInterface` is missing an `@api` or `@internal` annotation.'
 count = 1
 
 [[issues]]
@@ -1846,6 +1882,12 @@ count = 1
 file = "src/RowGateway/AbstractRowGateway.php"
 code = "imprecise-type"
 message = "Type `array` in return type of `toArray` is imprecise, equivalent to `array<array-key, mixed>`."
+count = 1
+
+[[issues]]
+file = "src/RowGateway/AbstractRowGateway.php"
+code = "incompatible-parameter-name"
+message = 'Parameter #1 of `PhpDb\RowGateway\AbstractRowGateway::populate()` is named `$rowData` but parent `PhpDb\ResultSet\RowPrototypeInterface::populate()` names it `$data`'
 count = 1
 
 [[issues]]
@@ -1892,6 +1934,18 @@ count = 1
 
 [[issues]]
 file = "src/RowGateway/AbstractRowGateway.php"
+code = "missing-override-attribute"
+message = 'Missing `#[Override]` attribute on overriding method `PhpDb\RowGateway\AbstractRowGateway::populate`.'
+count = 1
+
+[[issues]]
+file = "src/RowGateway/AbstractRowGateway.php"
+code = "missing-override-attribute"
+message = 'Missing `#[Override]` attribute on overriding method `PhpDb\RowGateway\AbstractRowGateway::toArray`.'
+count = 1
+
+[[issues]]
+file = "src/RowGateway/AbstractRowGateway.php"
 code = "missing-template-parameter"
 message = "Too few template arguments for `ArrayAccess`: expected at least 2, but found 0."
 count = 1
@@ -1919,6 +1973,12 @@ file = "src/RowGateway/AbstractRowGateway.php"
 code = "mixed-method-access"
 message = "Attempting to access a method on a non-object type (`mixed`)."
 count = 14
+
+[[issues]]
+file = "src/RowGateway/AbstractRowGateway.php"
+code = "mixed-operand"
+message = "Invalid middle operand: type `mixed` cannot be reliably used in string concatenation."
+count = 1
 
 [[issues]]
 file = "src/RowGateway/AbstractRowGateway.php"
@@ -5011,12 +5071,6 @@ message = "Class constant `TYPE_VALUE` is missing a type hint."
 count = 1
 
 [[issues]]
-file = "src/Sql/TableIdentifier.php"
-code = "class-must-be-final"
-message = 'Class `PhpDb\Sql\TableIdentifier` should be declared `final`.'
-count = 1
-
-[[issues]]
 file = "src/Sql/Update.php"
 code = "class-must-be-final"
 message = 'Class `PhpDb\Sql\Update` should be declared `final`.'
@@ -5987,12 +6041,6 @@ file = "src/TableGateway/Feature/RowGatewayFeature.php"
 code = "class-must-be-final"
 message = 'Class `PhpDb\TableGateway\Feature\RowGatewayFeature` should be declared `final`.'
 count = 1
-
-[[issues]]
-file = "src/TableGateway/Feature/RowGatewayFeature.php"
-code = "deprecated-method"
-message = 'Call to deprecated method: `PhpDb\ResultSet\ResultSet::setArrayObjectPrototype`.'
-count = 3
 
 [[issues]]
 file = "src/TableGateway/Feature/RowGatewayFeature.php"

--- a/lint-baseline.toml
+++ b/lint-baseline.toml
@@ -260,12 +260,6 @@ count = 2
 
 [[issues]]
 file = "src/ResultSet/AbstractResultSet.php"
-code = "kan-defect"
-message = "Class has a high kan defect score."
-count = 1
-
-[[issues]]
-file = "src/ResultSet/AbstractResultSet.php"
 code = "no-else-clause"
 message = "Avoid `else` clauses."
 count = 1
@@ -274,13 +268,31 @@ count = 1
 file = "src/ResultSet/AbstractResultSet.php"
 code = "no-else-clause"
 message = "Avoid `elseif` clauses."
-count = 2
+count = 3
 
 [[issues]]
 file = "src/ResultSet/AbstractResultSet.php"
 code = "no-isset"
 message = "Use of the `isset` construct."
 count = 2
+
+[[issues]]
+file = "src/ResultSet/AbstractResultSet.php"
+code = "no-redundant-else"
+message = "The `if` branch always terminates; the trailing branches can be extracted."
+count = 1
+
+[[issues]]
+file = "src/ResultSet/AbstractResultSet.php"
+code = "yoda-conditions"
+message = "Use Yoda condition style for safer comparisons"
+count = 5
+
+[[issues]]
+file = "src/ResultSet/ArrayObjectResultSetInterface.php"
+code = "prefer-self-return-type"
+message = "Return type `ArrayObjectResultSetInterface` refers to the enclosing class; use `self` instead."
+count = 1
 
 [[issues]]
 file = "src/ResultSet/HydratingResultSet.php"
@@ -298,6 +310,42 @@ count = 1
 file = "src/ResultSet/HydratingResultSet.php"
 code = "no-isset"
 message = "Use of the `isset` construct."
+count = 1
+
+[[issues]]
+file = "src/ResultSet/HydratingResultSet.php"
+code = "yoda-conditions"
+message = "Use Yoda condition style for safer comparisons"
+count = 1
+
+[[issues]]
+file = "src/ResultSet/HydratingResultSetInterface.php"
+code = "prefer-self-return-type"
+message = "Return type `HydratingResultSetInterface` refers to the enclosing class; use `self` instead."
+count = 1
+
+[[issues]]
+file = "src/ResultSet/ResultSet.php"
+code = "yoda-conditions"
+message = "Use Yoda condition style for safer comparisons"
+count = 1
+
+[[issues]]
+file = "src/ResultSet/ResultSetInterface.php"
+code = "prefer-self-return-type"
+message = "Return type `ResultSetInterface` refers to the enclosing class; use `self` instead."
+count = 1
+
+[[issues]]
+file = "src/ResultSet/RowPrototypeInterface.php"
+code = "prefer-self-return-type"
+message = "Return type `RowPrototypeInterface` refers to the enclosing class; use `self` instead."
+count = 1
+
+[[issues]]
+file = "src/ResultSet/RowPrototypeResultSetInterface.php"
+code = "prefer-self-return-type"
+message = "Return type `RowPrototypeResultSetInterface` refers to the enclosing class; use `self` instead."
 count = 1
 
 [[issues]]
@@ -344,9 +392,27 @@ count = 1
 
 [[issues]]
 file = "src/RowGateway/AbstractRowGateway.php"
+code = "prefer-early-continue"
+message = "Consider using early continue pattern to reduce nesting."
+count = 1
+
+[[issues]]
+file = "src/RowGateway/AbstractRowGateway.php"
+code = "string-style"
+message = "String concatenation can be replaced with interpolation."
+count = 2
+
+[[issues]]
+file = "src/RowGateway/AbstractRowGateway.php"
 code = "too-many-methods"
 message = "Class has too many methods."
 count = 1
+
+[[issues]]
+file = "src/RowGateway/AbstractRowGateway.php"
+code = "yoda-conditions"
+message = "Use Yoda condition style for safer comparisons"
+count = 6
 
 [[issues]]
 file = "src/RowGateway/Feature/FeatureSet.php"
@@ -959,6 +1025,18 @@ file = "src/TableGateway/Feature/RowGatewayFeature.php"
 code = "no-isset"
 message = "Use of the `isset` construct."
 count = 2
+
+[[issues]]
+file = "src/TableGateway/Feature/RowGatewayFeature.php"
+code = "no-redundant-use"
+message = 'Redundant import: `MetadataFeature` is already in the current namespace `PhpDb\TableGateway\Feature`.'
+count = 1
+
+[[issues]]
+file = "src/TableGateway/Feature/RowGatewayFeature.php"
+code = "yoda-conditions"
+message = "Use Yoda condition style for safer comparisons"
+count = 1
 
 [[issues]]
 file = "src/TableGateway/Feature/SequenceFeature.php"
@@ -2914,7 +2992,13 @@ count = 1
 file = "test/unit/ResultSet/AbstractResultSetTest.php"
 code = "assertion-style"
 message = "Inconsistent assertions style."
-count = 47
+count = 45
+
+[[issues]]
+file = "test/unit/ResultSet/AbstractResultSetTest.php"
+code = "prefer-static-closure"
+message = "This closure does not use `$this` and should be declared static."
+count = 1
 
 [[issues]]
 file = "test/unit/ResultSet/AbstractResultSetTest.php"
@@ -3075,24 +3159,6 @@ count = 1
 [[issues]]
 file = "test/unit/ResultSet/AbstractResultSetTest.php"
 code = "prefer-test-attribute"
-message = "Use `#[Test]` attribute instead of `test` prefix on method `testToArrayConvertsArrayObjectsViaGetArrayCopy`."
-count = 1
-
-[[issues]]
-file = "test/unit/ResultSet/AbstractResultSetTest.php"
-code = "prefer-test-attribute"
-message = "Use `#[Test]` attribute instead of `test` prefix on method `testToArrayThrowsOnNonCastableRows`."
-count = 1
-
-[[issues]]
-file = "test/unit/ResultSet/AbstractResultSetTest.php"
-code = "prefer-test-attribute"
-message = "Use `#[Test]` attribute instead of `test` prefix on method `testToArray`."
-count = 1
-
-[[issues]]
-file = "test/unit/ResultSet/AbstractResultSetTest.php"
-code = "prefer-test-attribute"
 message = "Use `#[Test]` attribute instead of `test` prefix on method `testValidReturnsFalseAfterLastElement`."
 count = 1
 
@@ -3220,7 +3286,7 @@ count = 27
 file = "test/unit/ResultSet/ResultSetIntegrationTest.php"
 code = "literal-named-argument"
 message = "Literal argument `75` should be passed as a named argument for clarity."
-count = 3
+count = 2
 
 [[issues]]
 file = "test/unit/ResultSet/ResultSetIntegrationTest.php"
@@ -3363,12 +3429,6 @@ count = 1
 [[issues]]
 file = "test/unit/ResultSet/ResultSetIntegrationTest.php"
 code = "prefer-test-attribute"
-message = "Use `#[Test]` attribute instead of `test` prefix on method `testToArrayRaisesExceptionForRowsThatAreNotArraysOrArrayCastable`."
-count = 1
-
-[[issues]]
-file = "test/unit/ResultSet/ResultSetIntegrationTest.php"
-code = "prefer-test-attribute"
 message = "Use `#[Test]` attribute instead of `test` prefix on method `testWhenReturnTypeIsArrayThenIterationReturnsArrays`."
 count = 1
 
@@ -3383,6 +3443,12 @@ file = "test/unit/ResultSet/ResultSetIntegrationTest.php"
 code = "strict-assertions"
 message = "Use strict assertions in PHPUnit tests."
 count = 2
+
+[[issues]]
+file = "test/unit/ResultSet/ResultSetIntegrationTest.php"
+code = "string-style"
+message = "String concatenation can be replaced with interpolation."
+count = 1
 
 [[issues]]
 file = "test/unit/RowGateway/AbstractRowGatewayTest.php"
@@ -9076,6 +9142,12 @@ count = 1
 file = "test/unit/TableGateway/Feature/RowGatewayFeatureTest.php"
 code = "prefer-test-attribute"
 message = "Use `#[Test]` attribute instead of `test` prefix on method `testPostInitializeWithStringPrimaryKey`."
+count = 1
+
+[[issues]]
+file = "test/unit/TableGateway/Feature/RowGatewayFeatureTest.php"
+code = "yoda-conditions"
+message = "Use Yoda condition style for safer comparisons"
 count = 1
 
 [[issues]]

--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -17,10 +17,7 @@ use ReturnTypeWillChange;
 
 use function count;
 use function current;
-use function gettype;
 use function is_array;
-use function is_object;
-use function method_exists;
 use function reset;
 
 abstract class AbstractResultSet implements ResultSetInterface
@@ -49,9 +46,7 @@ abstract class AbstractResultSet implements ResultSetInterface
     {
         if ($this->buffer === -2) {
             throw new RuntimeException('Buffering must be enabled before iteration is started');
-        }
-
-        if (null === $this->buffer) {
+        } elseif ($this->buffer === null) {
             $this->buffer = [];
             if ($this->dataSource instanceof ResultInterface) {
                 $this->dataSource->rewind();
@@ -68,7 +63,7 @@ abstract class AbstractResultSet implements ResultSetInterface
     #[ReturnTypeWillChange]
     public function count(): ?int
     {
-        if (null !== $this->count) {
+        if ($this->count !== null) {
             return $this->count;
         }
 
@@ -90,7 +85,7 @@ abstract class AbstractResultSet implements ResultSetInterface
             return $this->dataSource->current();
         }
 
-        if (null === $this->buffer) {
+        if ($this->buffer === null) {
             $this->buffer = -2; // implicitly disable buffering from here on
         } elseif (is_array($this->buffer) && isset($this->buffer[$this->position])) {
             return $this->buffer[$this->position];
@@ -175,7 +170,7 @@ abstract class AbstractResultSet implements ResultSetInterface
             // its safe to get numbers from an array
             $first = current($dataSource);
             reset($dataSource);
-            $this->fieldCount = false === $first ? 0 : count($first);
+            $this->fieldCount = $first === false ? 0 : count($first);
             $this->dataSource = new ArrayIterator($dataSource);
             $this->buffer     = -1; // array's are a natural buffer
         } elseif ($dataSource instanceof IteratorAggregate) {
@@ -209,7 +204,7 @@ abstract class AbstractResultSet implements ResultSetInterface
     #[Override]
     public function next(): void
     {
-        if (null === $this->buffer) {
+        if ($this->buffer === null) {
             $this->buffer = -2; // implicitly disable buffering from here on
         }
 
@@ -231,39 +226,6 @@ abstract class AbstractResultSet implements ResultSetInterface
         }
 
         $this->position = 0;
-    }
-
-    /**
-     * Cast result set to array of arrays
-     *
-     * @throws RuntimeException If any row is not castable to an array.
-     */
-    #[Override]
-    public function toArray(): array
-    {
-        $return = [];
-        foreach ($this as $row) {
-            if (is_array($row)) {
-                $return[] = $row;
-                continue;
-            }
-
-            if (
-                ! is_object($row)
-                    || (
-                        ! method_exists($row, 'toArray')
-                        && ! method_exists($row, 'getArrayCopy')
-                    )
-            ) {
-                throw new RuntimeException(
-                    'Rows as part of this DataSource, with type ' . gettype($row) . ' cannot be cast to an array',
-                );
-            }
-
-            $return[] = method_exists($row, 'toArray') ? $row->toArray() : $row->getArrayCopy();
-        }
-
-        return $return;
     }
 
     /**

--- a/src/ResultSet/ArrayObjectResultSetInterface.php
+++ b/src/ResultSet/ArrayObjectResultSetInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDb\ResultSet;
+
+use ArrayObject;
+
+/**
+ * Capability interface for a ResultSet whose rows clone an ArrayObject prototype.
+ */
+interface ArrayObjectResultSetInterface
+{
+    public function getRowPrototype(): ArrayObject;
+
+    public function setRowPrototype(ArrayObject $rowPrototype): ResultSetInterface&ArrayObjectResultSetInterface;
+}

--- a/src/ResultSet/ArrayResultSet.php
+++ b/src/ResultSet/ArrayResultSet.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDb\ResultSet;
+
+use Override;
+
+class ArrayResultSet extends AbstractResultSet
+{
+    /** {@inheritDoc} */
+    #[Override]
+    public function toArray(): array
+    {
+        $return = [];
+        foreach ($this as $row) {
+            $return[] = $row;
+        }
+
+        return $return;
+    }
+}

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -11,7 +11,7 @@ use Override;
 
 use function is_array;
 
-class HydratingResultSet extends AbstractResultSet
+class HydratingResultSet extends AbstractResultSet implements HydratingResultSetInterface
 {
     public function __construct(
         private ?HydratorInterface $hydrator = null,
@@ -24,7 +24,7 @@ class HydratingResultSet extends AbstractResultSet
     #[Override]
     public function current(): ?object
     {
-        if (null === $this->buffer) {
+        if ($this->buffer === null) {
             $this->buffer = -2; // implicitly disable buffering from here on
         } elseif (is_array($this->buffer) && isset($this->buffer[$this->position])) {
             return $this->buffer[$this->position];
@@ -77,7 +77,7 @@ class HydratingResultSet extends AbstractResultSet
 
     /** {@inheritDoc} */
     #[Override]
-    public function setRowPrototype(object $rowPrototype): ResultSetInterface
+    public function setRowPrototype(object $rowPrototype): ResultSetInterface&HydratingResultSetInterface
     {
         $this->rowPrototype = $rowPrototype;
         return $this;

--- a/src/ResultSet/HydratingResultSetInterface.php
+++ b/src/ResultSet/HydratingResultSetInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDb\ResultSet;
+
+/**
+ * Capability interface for a ResultSet whose rows are hydrated onto an arbitrary object prototype.
+ */
+interface HydratingResultSetInterface
+{
+    public function getRowPrototype(): object;
+
+    public function setRowPrototype(object $rowPrototype): ResultSetInterface&HydratingResultSetInterface;
+}

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -10,7 +10,7 @@ use Override;
 use function is_array;
 use function is_string;
 
-class ResultSet extends AbstractResultSet
+class ResultSet extends AbstractResultSet implements ArrayObjectResultSetInterface
 {
     /** @deprecated use ResultSetReturnType */
     public const TYPE_ARRAYOBJECT = 'arrayobject';
@@ -18,7 +18,7 @@ class ResultSet extends AbstractResultSet
 
     public function __construct(
         private ResultSetReturnType|string $returnType = ResultSetReturnType::ArrayObject,
-        private ArrayObject|RowPrototypeInterface|null $rowPrototype = new ArrayObject(
+        private ArrayObject $rowPrototype = new ArrayObject(
             [],
             ArrayObject::ARRAY_AS_PROPS,
         ),
@@ -32,11 +32,11 @@ class ResultSet extends AbstractResultSet
      * Iterator: get current item
      */
     #[Override]
-    public function current(): array|ArrayObject|RowPrototypeInterface|null
+    public function current(): array|ArrayObject|null
     {
         $data = parent::current();
 
-        if (ResultSetReturnType::ArrayObject === $this->returnType && is_array($data)) {
+        if ($this->returnType === ResultSetReturnType::ArrayObject && is_array($data)) {
             $ao = clone $this->getRowPrototype();
             $ao->exchangeArray($data);
 
@@ -49,7 +49,7 @@ class ResultSet extends AbstractResultSet
     /**
      * @deprecated use getRowPrototype()
      */
-    public function getArrayObjectPrototype(): ArrayObject|RowPrototypeInterface
+    public function getArrayObjectPrototype(): ArrayObject
     {
         return $this->getRowPrototype();
     }
@@ -64,7 +64,7 @@ class ResultSet extends AbstractResultSet
 
     /** {@inheritDoc} */
     #[Override]
-    public function getRowPrototype(): ArrayObject|RowPrototypeInterface
+    public function getRowPrototype(): ArrayObject
     {
         return $this->rowPrototype;
     }
@@ -74,17 +74,29 @@ class ResultSet extends AbstractResultSet
      *
      * @deprecated use setRowPrototype()
      */
-    public function setArrayObjectPrototype(ArrayObject|RowPrototypeInterface $arrayObjectPrototype): ResultSetInterface
+    public function setArrayObjectPrototype(ArrayObject $arrayObjectPrototype): ResultSetInterface&ArrayObjectResultSetInterface
     {
         return $this->setRowPrototype($arrayObjectPrototype);
     }
 
     /** {@inheritDoc} */
     #[Override]
-    public function setRowPrototype(ArrayObject|RowPrototypeInterface $rowPrototype): ResultSetInterface
+    public function setRowPrototype(ArrayObject $rowPrototype): ResultSetInterface&ArrayObjectResultSetInterface
     {
         $this->rowPrototype = $rowPrototype;
 
         return $this;
+    }
+
+    /** {@inheritDoc} */
+    #[Override]
+    public function toArray(): array
+    {
+        $return = [];
+        foreach ($this as $row) {
+            $return[] = $row instanceof ArrayObject ? $row->getArrayCopy() : $row;
+        }
+
+        return $return;
     }
 }

--- a/src/ResultSet/ResultSetInterface.php
+++ b/src/ResultSet/ResultSetInterface.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpDb\ResultSet;
 
-use ArrayObject;
 use Countable;
 use Iterator;
 
@@ -18,26 +17,12 @@ interface ResultSetInterface extends Iterator, Countable
     public function getFieldCount(): int;
 
     /**
-     * Get the row object prototype
-     */
-    public function getRowPrototype(): ?object;
-
-    /**
      * Can be anything iterable|array
      */
-    public function initialize(iterable $dataSource): self;
-
-    /**
-     * Set the row object prototype
-     *
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setRowPrototype(ArrayObject|RowPrototypeInterface $rowPrototype): self;
+    public function initialize(iterable $dataSource): ResultSetInterface;
 
     /**
      * Get all rows as an array
-     *
-     * @return RowPrototypeInterface[]|ArrayObject[]|array[]
      */
     public function toArray(): array;
 }

--- a/src/ResultSet/RowPrototypeInterface.php
+++ b/src/ResultSet/RowPrototypeInterface.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 namespace PhpDb\ResultSet;
 
 /**
- * Interface for objects that can serve as row prototypes in ResultSets.
+ * Interface for objects that can serve as row prototypes in RowPrototypeResultSets.
  *
- * Row prototypes are cloned for each row and populated via exchangeArray().
+ * Row prototypes are cloned (but do not have to be) for each row and populated via populate().
  * This interface allows custom row objects (like RowGateway) to be used
- * as prototypes alongside ArrayObject.
+ * as prototypes without depending on ArrayObject.
  */
 interface RowPrototypeInterface
 {
     /**
-     * Exchange the current data for the provided array.
+     * Populate the prototype with row data. Mutating vs. returning a new instance is up to the implementation.
      */
-    public function exchangeArray(array $array): array;
+    public function populate(array $data): RowPrototypeInterface;
 
     /**
      * Current data as an array and match current RowGateway implementations.

--- a/src/ResultSet/RowPrototypeResultSet.php
+++ b/src/ResultSet/RowPrototypeResultSet.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDb\ResultSet;
+
+use Override;
+
+use function is_array;
+
+class RowPrototypeResultSet extends AbstractResultSet implements RowPrototypeResultSetInterface
+{
+    public function __construct(
+        private RowPrototypeInterface $rowPrototype,
+    ) {}
+
+    /**
+     * Iterator: get current item
+     */
+    #[Override]
+    public function current(): array|RowPrototypeInterface|null
+    {
+        $data = parent::current();
+
+        if (is_array($data)) {
+            return (clone $this->getRowPrototype())->populate($data);
+        }
+
+        return $data;
+    }
+
+    /** {@inheritDoc} */
+    #[Override]
+    public function getRowPrototype(): RowPrototypeInterface
+    {
+        return $this->rowPrototype;
+    }
+
+    /** {@inheritDoc} */
+    #[Override]
+    public function setRowPrototype(RowPrototypeInterface $rowPrototype): ResultSetInterface&RowPrototypeResultSetInterface
+    {
+        $this->rowPrototype = $rowPrototype;
+
+        return $this;
+    }
+
+    /** {@inheritDoc} */
+    #[Override]
+    public function toArray(): array
+    {
+        $return = [];
+        foreach ($this as $row) {
+            $return[] = $row instanceof RowPrototypeInterface ? $row->toArray() : $row;
+        }
+
+        return $return;
+    }
+}

--- a/src/ResultSet/RowPrototypeResultSetInterface.php
+++ b/src/ResultSet/RowPrototypeResultSetInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDb\ResultSet;
+
+/**
+ * Capability interface for a ResultSet whose rows clone a RowPrototypeInterface prototype.
+ */
+interface RowPrototypeResultSetInterface
+{
+    public function getRowPrototype(): RowPrototypeInterface;
+
+    public function setRowPrototype(RowPrototypeInterface $rowPrototype): ResultSetInterface&RowPrototypeResultSetInterface;
+}

--- a/src/RowGateway/AbstractRowGateway.php
+++ b/src/RowGateway/AbstractRowGateway.php
@@ -54,7 +54,7 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
         $result       = $statement->execute();
 
         $rowsAffected = $result->getAffectedRows();
-        if (1 === $rowsAffected) {
+        if ($rowsAffected === 1) {
             $this->primaryKeyData = null;
         }
 
@@ -67,7 +67,6 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
      *
      * @return array<string, mixed>
      */
-    #[Override]
     public function exchangeArray(array $array): array
     {
         $oldData = $this->data;
@@ -93,15 +92,15 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
         $this->featureSet->setRowGateway($this);
         $this->featureSet->apply('preInitialize', []);
 
-        if (null === $this->table) {
+        if ($this->table === null) {
             throw new Exception\RuntimeException('This row object does not have a valid table set.');
         }
 
-        if (null === $this->primaryKeyColumn) {
+        if ($this->primaryKeyColumn === null) {
             throw new Exception\RuntimeException('This row object does not have a primary key column set.');
         }
 
-        if (null === $this->sql) {
+        if ($this->sql === null) {
             throw new Exception\RuntimeException('This row object does not have a Sql object set.');
         }
 
@@ -165,12 +164,12 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
     /**
      * Populate Data
      */
-    public function populate(array $rowData, bool $rowExistsInDatabase = false): RowGatewayInterface
+    public function populate(array $rowData, bool $rowExistsInDatabase = false): static
     {
         $this->initialize();
 
         $this->data = $rowData;
-        if (true === $rowExistsInDatabase) {
+        if ($rowExistsInDatabase === true) {
             $this->processPrimaryKeyData();
         } else {
             $this->primaryKeyData = null;
@@ -181,7 +180,7 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
 
     public function rowExistsInDatabase(): bool
     {
-        return null !== $this->primaryKeyData;
+        return $this->primaryKeyData !== null;
     }
 
     #[Override]
@@ -212,11 +211,9 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
 
             if ($isPkModified) {
                 foreach ($this->primaryKeyColumn as $pkColumn) {
-                    if ($data[$pkColumn] === $this->primaryKeyData[$pkColumn]) {
-                        continue;
+                    if ($data[$pkColumn] !== $this->primaryKeyData[$pkColumn]) {
+                        $where[$pkColumn] = $data[$pkColumn];
                     }
-
-                    $where[$pkColumn] = $data[$pkColumn];
                 }
             }
         } else {
@@ -249,7 +246,6 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
         return $rowsAffected;
     }
 
-    #[Override]
     public function toArray(): array
     {
         return $this->data;
@@ -264,7 +260,7 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
         foreach ($this->primaryKeyColumn as $column) {
             if (! isset($this->data[$column])) {
                 throw new Exception\RuntimeException(
-                    "While processing primary key data, a known key {$column} was not found in the data array",
+                    'While processing primary key data, a known key ' . $column . ' was not found in the data array',
                 );
             }
             $this->primaryKeyData[$column] = $this->data[$column];
@@ -279,7 +275,7 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
         if (array_key_exists($name, $this->data)) {
             return $this->data[$name];
         }
-        throw new Exception\InvalidArgumentException("Not a valid column in this row: {$name}");
+        throw new Exception\InvalidArgumentException('Not a valid column in this row: ' . $name);
     }
 
     public function __isset(string $name): bool

--- a/src/TableGateway/Feature/RowGatewayFeature.php
+++ b/src/TableGateway/Feature/RowGatewayFeature.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PhpDb\TableGateway\Feature;
 
-use PhpDb\ResultSet\ResultSet;
+use PhpDb\ResultSet\RowPrototypeResultSet;
 use PhpDb\RowGateway\RowGateway;
 use PhpDb\RowGateway\RowGatewayInterface;
 use PhpDb\TableGateway\Exception;
+use PhpDb\TableGateway\Feature\MetadataFeature;
 
 use function is_string;
 
@@ -24,12 +25,15 @@ class RowGatewayFeature extends AbstractFeature
     {
         $args = $this->constructorArguments;
 
-        /** @var ResultSet $resultSetPrototype */
+        /** @var RowPrototypeResultSet $resultSetPrototype */
         $resultSetPrototype = $this->tableGateway->resultSetPrototype;
 
-        if (! $this->tableGateway->resultSetPrototype instanceof ResultSet) {
+        if (! $this->tableGateway->resultSetPrototype instanceof RowPrototypeResultSet) {
             throw new Exception\RuntimeException(
-                'This feature ' . self::class . ' expects the ResultSet to be an instance of ' . ResultSet::class,
+                'This feature '
+                    . self::class
+                    . ' expects the ResultSet to be an instance of '
+                    . RowPrototypeResultSet::class,
             );
         }
 
@@ -41,17 +45,17 @@ class RowGatewayFeature extends AbstractFeature
                     $this->tableGateway->table,
                     $this->tableGateway->adapter,
                 );
-                $resultSetPrototype->setArrayObjectPrototype($rowGatewayPrototype);
+                $resultSetPrototype->setRowPrototype($rowGatewayPrototype);
             } elseif ($args[0] instanceof RowGatewayInterface) {
                 $rowGatewayPrototype = $args[0];
-                $resultSetPrototype->setArrayObjectPrototype($rowGatewayPrototype);
+                $resultSetPrototype->setRowPrototype($rowGatewayPrototype);
             }
         } else {
             // get from metadata feature
             $metadata = $this->tableGateway->featureSet->getFeatureByClassName(
                 MetadataFeature::class,
             );
-            if (null === $metadata || ! isset($metadata->sharedData['metadata'])) {
+            if ($metadata === null || ! isset($metadata->sharedData['metadata'])) {
                 throw new Exception\RuntimeException(
                     'No information was provided to the RowGatewayFeature and/or no MetadataFeature could be consulted '
                         . 'to find the primary key necessary for RowGateway object creation.',
@@ -63,7 +67,7 @@ class RowGatewayFeature extends AbstractFeature
                 $this->tableGateway->table,
                 $this->tableGateway->adapter,
             );
-            $resultSetPrototype->setArrayObjectPrototype($rowGatewayPrototype);
+            $resultSetPrototype->setRowPrototype($rowGatewayPrototype);
         }
     }
 }

--- a/test/unit/ResultSet/AbstractResultSetIntegrationTest.php
+++ b/test/unit/ResultSet/AbstractResultSetIntegrationTest.php
@@ -58,7 +58,7 @@ final class AbstractResultSetIntegrationTest extends TestCase
     protected function setUp(): void
     {
         $this->resultSet = $this->getMockBuilder(AbstractResultSet::class)
-            ->onlyMethods(['setRowPrototype', 'getRowPrototype'])
+            ->onlyMethods(['toArray'])
             ->getMock();
     }
 }

--- a/test/unit/ResultSet/AbstractResultSetTest.php
+++ b/test/unit/ResultSet/AbstractResultSetTest.php
@@ -19,7 +19,6 @@ use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 use TypeError;
 
 use function assert;
@@ -35,7 +34,6 @@ use function assert;
 #[CoversMethod(AbstractResultSet::class, 'valid')]
 #[CoversMethod(AbstractResultSet::class, 'rewind')]
 #[CoversMethod(AbstractResultSet::class, 'count')]
-#[CoversMethod(AbstractResultSet::class, 'toArray')]
 final class AbstractResultSetTest extends TestCase
 {
     protected MockObject|AbstractResultSet $resultSet;
@@ -387,7 +385,7 @@ final class AbstractResultSetTest extends TestCase
         assert($stub instanceof PDOStatement); // to suppress IDE type warnings
         $stub->expects($this->any())
             ->method('fetch')
-            ->willReturnCallback(static function () use ($data) {
+            ->willReturnCallback(function () use ($data) {
                 $r = $data->current();
                 $data->next();
                 return $r;
@@ -485,50 +483,6 @@ final class AbstractResultSetTest extends TestCase
     /**
      * @throws Exception
      */
-    public function testToArray(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([
-            ['id' => 1, 'name' => 'one'],
-            ['id' => 2, 'name' => 'two'],
-            ['id' => 3, 'name' => 'three'],
-        ]));
-        // Verify toArray() returns all rows as array
-        self::assertEquals(
-            [
-                ['id' => 1, 'name' => 'one'],
-                ['id' => 2, 'name' => 'two'],
-                ['id' => 3, 'name' => 'three'],
-            ],
-            $resultSet->toArray(),
-        );
-    }
-
-    public function testToArrayConvertsArrayObjectsViaGetArrayCopy(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize([
-            new ArrayObject(['id' => 1, 'name' => 'one']),
-        ]);
-
-        $result = $resultSet->toArray();
-
-        self::assertSame([['id' => 1, 'name' => 'one']], $result);
-    }
-
-    public function testToArrayThrowsOnNonCastableRows(): void
-    {
-        $resultSet = $this->createResultSetMock();
-        $resultSet->initialize(new ArrayIterator([new stdClass()]));
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('cannot be cast to an array');
-        $resultSet->toArray();
-    }
-
-    /**
-     * @throws Exception
-     */
     public function testValid(): void
     {
         $resultSet = $this->createResultSetMock();
@@ -587,7 +541,7 @@ final class AbstractResultSetTest extends TestCase
     private function createResultSetMock(): MockObject|AbstractResultSet
     {
         return $this->getMockBuilder(AbstractResultSet::class)
-            ->onlyMethods(['setRowPrototype', 'getRowPrototype'])
+            ->onlyMethods(['toArray'])
             ->getMock();
     }
 }

--- a/test/unit/ResultSet/ArrayResultSetTest.php
+++ b/test/unit/ResultSet/ArrayResultSetTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDbTest\ResultSet;
+
+use PhpDb\ResultSet\ArrayResultSet;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversMethod(ArrayResultSet::class, 'toArray')]
+#[Group('unit')]
+final class ArrayResultSetTest extends TestCase
+{
+    #[Test]
+    public function toArrayReturnsRowsAsProvided(): void
+    {
+        $resultSet = new ArrayResultSet();
+        $resultSet->initialize([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+        ]);
+
+        static::assertSame(
+            [
+                ['id' => 1, 'name' => 'one'],
+                ['id' => 2, 'name' => 'two'],
+            ],
+            $resultSet->toArray(),
+        );
+    }
+}

--- a/test/unit/ResultSet/ResultSetIntegrationTest.php
+++ b/test/unit/ResultSet/ResultSetIntegrationTest.php
@@ -56,7 +56,7 @@ final class ResultSetIntegrationTest extends TestCase
         for ($i = 0; $i < $count; $i++) {
             $array[] = [
                 'id'    => $i,
-                'title' => "title {$i}",
+                'title' => 'title ' . $i,
             ];
         }
 
@@ -321,24 +321,6 @@ final class ResultSetIntegrationTest extends TestCase
         $this->resultSet->initialize($dataSource);
         $test = $this->resultSet->toArray();
         self::assertEquals($dataSource->getArrayCopy(), $test, var_export($test, true));
-    }
-
-    /**
-     * @throws RandomException
-     * @throws \Exception
-     */
-    public function testToArrayRaisesExceptionForRowsThatAreNotArraysOrArrayCastable(): void
-    {
-        $count      = random_int(3, 75);
-        $dataSource = $this->getArrayDataSource($count);
-        foreach ($dataSource as $index => $row) {
-            $dataSource[$index] = (object) $row;
-        }
-
-        // Verify toArray() throws exception for non-array-castable objects
-        $this->resultSet->initialize($dataSource);
-        $this->expectException(RuntimeException::class);
-        $this->resultSet->toArray();
     }
 
     /**

--- a/test/unit/ResultSet/ResultSetIntegrationTest.php
+++ b/test/unit/ResultSet/ResultSetIntegrationTest.php
@@ -32,6 +32,10 @@ use function var_export;
 #[CoversMethod(ResultSet::class, 'getReturnType')]
 #[CoversMethod(ResultSet::class, '__construct')]
 #[CoversMethod(ResultSet::class, 'getArrayObjectPrototype')]
+#[CoversMethod(ResultSet::class, 'getRowPrototype')]
+#[CoversMethod(ResultSet::class, 'setArrayObjectPrototype')]
+#[CoversMethod(ResultSet::class, 'setRowPrototype')]
+#[CoversMethod(ResultSet::class, 'toArray')]
 #[Group('unit')]
 final class ResultSetIntegrationTest extends TestCase
 {

--- a/test/unit/ResultSet/RowPrototypeResultSetTest.php
+++ b/test/unit/ResultSet/RowPrototypeResultSetTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpDbTest\ResultSet;
+
+use ArrayIterator;
+use PhpDb\ResultSet\RowPrototypeInterface;
+use PhpDb\ResultSet\RowPrototypeResultSet;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversMethod(RowPrototypeResultSet::class, 'current')]
+#[CoversMethod(RowPrototypeResultSet::class, 'toArray')]
+#[Group('unit')]
+final class RowPrototypeResultSetTest extends TestCase
+{
+    #[Test]
+    public function currentReturnsDataUnchangedWhenNotArray(): void
+    {
+        $prototype = $this->createRowPrototype();
+        $resultSet = new RowPrototypeResultSet($prototype);
+        $resultSet->initialize(new ArrayIterator([null]));
+
+        static::assertNull($resultSet->current());
+    }
+
+    #[Test]
+    public function currentReturnsPopulatedCloneOfPrototypeForArrayRow(): void
+    {
+        $prototype = $this->createRowPrototype();
+        $resultSet = new RowPrototypeResultSet($prototype);
+        $resultSet->initialize(new ArrayIterator([
+            ['id' => 1, 'name' => 'one'],
+        ]));
+
+        $current = $resultSet->current();
+
+        static::assertInstanceOf(RowPrototypeInterface::class, $current);
+        static::assertNotSame($prototype, $current);
+        static::assertSame(['id' => 1, 'name' => 'one'], $current->toArray());
+    }
+
+    #[Test]
+    public function toArrayConvertsPrototypeRowsToArrays(): void
+    {
+        $prototype = $this->createRowPrototype();
+        $resultSet = new RowPrototypeResultSet($prototype);
+        $resultSet->initialize(new ArrayIterator([
+            ['id' => 1],
+            ['id' => 2],
+        ]));
+
+        static::assertSame(
+            [
+                ['id' => 1],
+                ['id' => 2],
+            ],
+            $resultSet->toArray(),
+        );
+    }
+
+    private function createRowPrototype(): RowPrototypeInterface
+    {
+        return new class implements RowPrototypeInterface {
+            private array $data = [];
+
+            public function populate(array $data): RowPrototypeInterface
+            {
+                $this->data = $data;
+
+                return $this;
+            }
+
+            public function toArray(): array
+            {
+                return $this->data;
+            }
+        };
+    }
+}

--- a/test/unit/TableGateway/Feature/RowGatewayFeatureTest.php
+++ b/test/unit/TableGateway/Feature/RowGatewayFeatureTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace PhpDbTest\TableGateway\Feature;
 
 use PhpDb\Adapter\AdapterInterface;
-use PhpDb\ResultSet\ResultSet;
 use PhpDb\ResultSet\ResultSetInterface;
+use PhpDb\ResultSet\RowPrototypeResultSet;
 use PhpDb\RowGateway\RowGatewayInterface;
 use PhpDb\TableGateway\AbstractTableGateway;
 use PhpDb\TableGateway\Exception\RuntimeException;
@@ -71,7 +71,7 @@ class RowGatewayFeatureTest extends TestCase
 
     public function testPostInitializeThrowsExceptionWhenMetadataHasNoMetadataKey(): void
     {
-        $resultSet = new ResultSet();
+        $resultSet = $this->createInitialResultSet();
 
         // Create a MetadataFeature mock without the metadata key in sharedData
         $metadataFeature = $this->getMockBuilder(MetadataFeature::class)
@@ -101,7 +101,7 @@ class RowGatewayFeatureTest extends TestCase
 
     public function testPostInitializeThrowsExceptionWhenNoMetadataAndNoPrimaryKey(): void
     {
-        $resultSet = new ResultSet();
+        $resultSet = $this->createInitialResultSet();
 
         $featureSet = $this->createMock(FeatureSet::class);
         $featureSet->expects($this->once())
@@ -122,7 +122,7 @@ class RowGatewayFeatureTest extends TestCase
 
     public function testPostInitializeWithMetadataFeature(): void
     {
-        $resultSet = new ResultSet();
+        $resultSet = $this->createInitialResultSet();
 
         // Create a MetadataFeature mock with primary key in sharedData
         $metadataFeature = $this->getMockBuilder(MetadataFeature::class)
@@ -154,7 +154,7 @@ class RowGatewayFeatureTest extends TestCase
 
     public function testPostInitializeWithRowGatewayInstance(): void
     {
-        $resultSet = new ResultSet();
+        $resultSet = $this->createInitialResultSet();
 
         /** @var RowGatewayInterface&MockObject $rowGateway */
         $rowGateway = $this->createMock(RowGatewayInterface::class);
@@ -171,7 +171,7 @@ class RowGatewayFeatureTest extends TestCase
 
     public function testPostInitializeWithStringPrimaryKey(): void
     {
-        $resultSet    = new ResultSet();
+        $resultSet    = $this->createInitialResultSet();
         $tableGateway = $this->createTableGatewayMock($resultSet);
 
         $feature = new RowGatewayFeature('id');
@@ -181,6 +181,14 @@ class RowGatewayFeatureTest extends TestCase
 
         $prototype = $resultSet->getRowPrototype();
         self::assertInstanceOf(RowGatewayInterface::class, $prototype);
+    }
+
+    /**
+     * RowPrototypeResultSet requires a prototype up front; postInitialize() always replaces it.
+     */
+    private function createInitialResultSet(): RowPrototypeResultSet
+    {
+        return new RowPrototypeResultSet($this->createMock(RowGatewayInterface::class));
     }
 
     private function createTableGatewayMock(
@@ -203,7 +211,7 @@ class RowGatewayFeatureTest extends TestCase
         $resultSetProperty = new ReflectionProperty(AbstractTableGateway::class, 'resultSetPrototype');
         $resultSetProperty->setValue($tableGateway, $resultSetPrototype);
 
-        if (null !== $featureSet) {
+        if ($featureSet !== null) {
             $featureSetProperty = new ReflectionProperty(AbstractTableGateway::class, 'featureSet');
             $featureSetProperty->setValue($tableGateway, $featureSet);
         }


### PR DESCRIPTION
- New RowPrototypeResultSet/RowPrototypeResultSetInterface: dedicated,
  ArrayObject-free ResultSet implementation for RowPrototypeInterface
  prototypes (e.g. RowGateway)
- Rename RowPrototypeInterface::exchangeArray() to populate(), returning
  RowPrototypeInterface. Avoids the ArrayObject-associated vocabulary
  bleeding across the ArrayObjectResultSet/RowPrototypeResultSet split;
  whether population is mutating or returns a new instance is left as an
  implementation detail of the prototype, not the ResultSet
- AbstractRowGateway::populate() return type widened to static to satisfy
  RowGatewayInterface's new populate() contract (behavior unchanged, it
  already returned $this)
- RowGatewayFeature migrated from ResultSet (now ArrayObject-only) to
  RowPrototypeResultSet, calling setRowPrototype() directly

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>